### PR TITLE
Use bg-opacity and text-opacity instead of opacity.

### DIFF
--- a/src/components/category.tsx
+++ b/src/components/category.tsx
@@ -3,17 +3,23 @@ import Subcategory from '../modules/models/subcategory';
 import SubcategoryComponent from './subcategory';
 import classNames from "classnames";
 
-const Category = ({ category }: any) => (
+const Category = ({ category }: any) => {
+  let hasVisibleContent = category.content.filter((el: Subcategory) => el.table.length).length > 0
+  return (
     <div className={classNames("rounded-md bg-gray-100 pt-4 m-2 overflow-hidden", {
-        'opacity-20': category.content.filter((el: Subcategory) => el.table.length).length === 0,
+      "bg-opacity-20": !hasVisibleContent,
     })}>
-        <h1 className="px-3 py-2 mx-3 mb-2 font-bold text-gray-800 bg-gray-200 rounded-md">{category.title}</h1>
-        {
-            category.content.map((subcategory: Subcategory, index: Number) => {
-                return subcategory.table.length > 0 && <SubcategoryComponent key={'Subcat-' + index} subcategory={subcategory} />;
-            })
-        }
+      <h1 className={classNames("px-3 py-2 mx-3 mb-2 font-bold text-gray-800 bg-gray-200 rounded-md", {
+        "bg-opacity-10": !hasVisibleContent,
+        "text-opacity-20": !hasVisibleContent
+      })}>{category.title}</h1>
+      {
+        category.content.map((subcategory: Subcategory, index: Number) => {
+          return subcategory.table.length > 0 && <SubcategoryComponent key={'Subcat-' + index} subcategory={subcategory} />;
+        })
+      }
     </div>
-);
+  )
+};
 
 export default Category;


### PR DESCRIPTION
When searching and scrolling down, category headings of empty categories might overlap with the search bar. This leads to the input being blocked. This happens because of the opacity value on the heading. This problem can be fixed by either adding `z-10` to the `SearchBar` component, or not using opacity on the `Category` component. Not using opacity seemed like the better solution to me, since it also fixes the overlap on the bottom banner.

I have added a screenshot below to visualize the problem:

![tailwind cheatsheet category bug](https://user-images.githubusercontent.com/46489795/119972221-40f7d600-bfb2-11eb-8118-7ccc3bda61d1.png)
