### PR TITLE
Move toggleCollapse to parent element. Open docs in new tab.

### DIFF
--- a/src/components/subcategory.tsx
+++ b/src/components/subcategory.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, MouseEvent } from 'react';
 import classNames from "classnames";
 import InfoTable from './infoTable';
 import useBus from 'use-bus';
@@ -6,8 +6,12 @@ import useBus from 'use-bus';
 const Subcategory = ({ subcategory }: any) => {
     const [isVisible, setIsVisible] = useState(false);
 
-    const toggleCollapse = (): any => {
+    const toggleCollapse = (): void => {
         setIsVisible(!isVisible);
+    };
+
+    const onClickLink = (event: MouseEvent<HTMLAnchorElement>): void => {
+        event.stopPropagation();
     };
 
     useBus(
@@ -22,9 +26,20 @@ const Subcategory = ({ subcategory }: any) => {
 
     return (
         <div>
-            <div className="flex items-center px-3 py-2 text-gray-700 border-gray-300 cursor-pointer hover:bg-gray-200 hover:text-gray-900">
-                <h1 className="flex-1 font-mono text-sm" onClick={toggleCollapse}>{subcategory.title}</h1>
-                <a className="px-2 py-1 text-xs font-bold text-white uppercase bg-gray-400 rounded-md hover:bg-primary" href={subcategory.docs}>Docs</a>
+            <div
+              className="flex items-center px-3 py-2 text-gray-700 border-gray-300 cursor-pointer hover:bg-gray-200 hover:text-gray-900"
+              onClick={toggleCollapse}
+            >
+                <h1 className="flex-1 font-mono text-sm">{subcategory.title}</h1>
+                <a
+                  className="px-2 py-1 text-xs font-bold text-white uppercase bg-gray-400 rounded-md hover:bg-primary"
+                  href={subcategory.docs}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={onClickLink}
+                >
+                  Docs
+                </a>
             </div>
             <div className={classNames('bg-gray-200 px-4 overflow-hidden', {
                 'h-0': !isVisible


### PR DESCRIPTION
I have pulled `toggleCollapse` from the `h1` element to the parent div, because both `cursor-pointer` and `hover:bg-gray-200` suggest that this is where the toggle is supposed to happen.

I also propose to open the docs in a new tab, because I think users want to use the cheatsheet and simultaneously browse the docs. I have added `target="_blank"` and `rel="noopener noreferrer"` for this purpose. To not trigger `toggleCollapse` of the parent div, the event propagation is canceled when the a tag is clicked.