### PR TITLE
Fix - Copy to clipboard

### DIFF
--- a/src/components/infoTable.tsx
+++ b/src/components/infoTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from "classnames";
-
+import { copyTextToClipboard } from '../utils/copyTextToClipboard';
+                                            
 const InfoTable = ({ table }: any) => {
     const parseText = (text: string): any => {
         if(text.includes("rgb(") || text === "transparent")
@@ -27,7 +28,11 @@ const InfoTable = ({ table }: any) => {
                                     tr.map((td: string, index: Number) => {
                                         return (
                                             <td 
-                                            onClick={() => { navigator.clipboard.writeText(td); alert(td + " Copied to clipboard") }}
+                                            onClick={async () => { 
+                                                await copyTextToClipboard(td).then(() =>
+                                                alert(td + " Copied to clipboard")
+                                              );
+                                             }}
                                             key={'td-' + index}
                                             className={classNames('font-mono cursor-copy text-xs hover:underline p-2 border-b border-gray-300', {
                                                 'text-purple-700 whitespace-nowrap': index === 0,

--- a/src/utils/copyTextToClipboard.ts
+++ b/src/utils/copyTextToClipboard.ts
@@ -1,0 +1,7 @@
+export async function copyTextToClipboard(text: string) {
+  if ("clipboard" in navigator) {
+    return await navigator.clipboard.writeText(text);
+  } else {
+    return document.execCommand("copy", true, text);
+  }
+}


### PR DESCRIPTION
This PR comes to fix a issue with copying to clipboard on macOS (at least). Related to [this](https://github.com/tailwindcomponents/cheatsheet/issues/13) open issue.

It has been tested on macOS Monterey 2.14 working properly. It would be interesting if someone test it on another OS.

Thanks to @khatabwedaa for the help.



Closes #13 