### PR TITLE
Fix - Fixed footer and apply dark background on short results

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Footer = (props: any) => (
-    <footer className="dark:bg-gray-900">
+    <footer className="mt-auto dark:bg-gray-900">
         <div className="container px-6 pt-16 mx-auto">
             <div className="flex flex-col items-center">
                 <div className="py-6 text-center sm:w-2/3">

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -48,7 +48,7 @@ const Home = (props: any) => {
     };
 
     return (
-        <main className={"tracking-wide font-roboto " + (JSON.parse(localStorage.getItem('darkMode') || '{}') ? 'dark' : '') }>
+        <main className={"tracking-wide font-roboto min-h-screen grid " + (JSON.parse(localStorage.getItem('darkMode') || '{}') ? 'dark bg-slate-900' : '')}>
             <SearchBar search={search} />
             <Categories cheatsheet={cheatsheet} />
             <Footer />


### PR DESCRIPTION
I love your project! 🚀
This PR fixes the footer when it has few or no search results. (light and dark mode).

Old version:
<img width="1440" alt="Captura de Pantalla 2022-07-19 a la(s) 23 47 27" src="https://user-images.githubusercontent.com/55862658/179885273-037aa2d3-3bb8-4abc-b8e5-8d64c6956af9.png">

New version:
<img width="1440" alt="Captura de Pantalla 2022-07-19 a la(s) 23 45 48" src="https://user-images.githubusercontent.com/55862658/179886062-c65f303d-cb08-4326-a1cd-664f961f5286.png">
