### PR TITLE
Improve class search performance

### DIFF
--- a/src/components/searchBar.tsx
+++ b/src/components/searchBar.tsx
@@ -2,6 +2,13 @@ import React, { useRef, useEffect } from 'react';
 import { ReactComponent as Logo } from '../images/logo.svg';
 import { dispatch } from 'use-bus';
 
+let searchTimeout: number | null = null
+function clearSearch() {
+    if (searchTimeout !== null) {
+        clearTimeout(searchTimeout)
+    }
+}
+
 const SearchBar = (props: any) => {
     const tailwindVersion = "3.0.24";
     const searchInput: any = useRef(null);
@@ -10,11 +17,18 @@ const SearchBar = (props: any) => {
         searchInput.current.focus();
     });
 
+    // The search is currently very expensive, as it redraws many elements on
+    // the screen. This little wrapper adds an artificial delay so that the
+    // app doesn't block user input.
     const search = (event: any) => {
         const text: string = event.target.value
-        if (0 < text.length && text.length < 4) return
-
-        props.search(text)
+        if (text.length < 5) {
+            clearSearch()
+            searchTimeout = window.setTimeout(() => props.search(text), 300)
+        } else {
+            clearSearch()
+            props.search(text)
+        }
     }
 
     return (

--- a/src/components/searchBar.tsx
+++ b/src/components/searchBar.tsx
@@ -10,6 +10,13 @@ const SearchBar = (props: any) => {
         searchInput.current.focus();
     });
 
+    const search = (event: any) => {
+        const text: string = event.target.value
+        if (text.length < 4) return
+
+        props.search(text)
+    }
+
     return (
         <div className="bg-white border-b dark:bg-gray-900 dark:border-gray-700 lg:fixed lg:w-full lg:top-0 lg:z-50 lg:left-0">
             <div className="container p-4 mx-auto">
@@ -19,7 +26,7 @@ const SearchBar = (props: any) => {
                         <h1 className="flex items-center pl-2 mt-2 text-lg text-gray-600 dark:border-gray-700 dark:text-gray-300 lg:mt-0 sm:ml-2 sm:border-l sm:border-gray-400">Cheatsheet <span className="flex items-center h-5 px-2 ml-2 text-xs font-bold text-white rounded-md bg-primary">{tailwindVersion}</span></h1>
                     </div>
 
-                    <input ref={searchInput} className="h-10 mt-4 text-gray-700 bg-white border border-gray-200 rounded-lg dark:bg-gray-900 lg:mt-0 2xl:w-96 dark:text-gray-300 dark:border-gray-600 focus:border-primary dark:focus:border-primary focus:outline-none focus:ring focus:ring-primary dark:placeholder-gray-400 focus:ring-opacity-20" type="text" placeholder="Search" onChange={props.search} />
+                    <input ref={searchInput} className="h-10 mt-4 text-gray-700 bg-white border border-gray-200 rounded-lg dark:bg-gray-900 lg:mt-0 2xl:w-96 dark:text-gray-300 dark:border-gray-600 focus:border-primary dark:focus:border-primary focus:outline-none focus:ring focus:ring-primary dark:placeholder-gray-400 focus:ring-opacity-20" type="text" placeholder="Search" onChange={search} />
 
                     <div className="flex flex-col mt-4 space-y-3 lg:mt-0 sm:flex-row sm:space-y-0 sm:space-x-3 sm:items-center sm:justify-center">
                         <button onClick={() => dispatch('ui/expand')} className="px-4 py-2 space-x-3 text-sm text-gray-600 transition-colors duration-300 transform border rounded-lg dark:text-gray-200 dark:border-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none">Expand <span className="lg:hidden xl:inline">All</span></button>

--- a/src/components/searchBar.tsx
+++ b/src/components/searchBar.tsx
@@ -12,7 +12,7 @@ const SearchBar = (props: any) => {
 
     const search = (event: any) => {
         const text: string = event.target.value
-        if (text.length < 4) return
+        if (0 < text.length && text.length < 4) return
 
         props.search(text)
     }

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -17,9 +17,7 @@ const Home = (props: any) => {
         trackView('/cheatsheet');
     }, []);
 
-    const search = (event: any) => {
-        const text: string = event.target.value;
-
+    const search = (text: string) => {
         let newCheatsheet: Category[] = json.map((category: Category) => {
             return {
                 ...category,


### PR DESCRIPTION
Hello!

I took a look at your cheatsheet, and while it has a good UI, the search performance is awful. This commit just prevents searching when the input size is less than 4 characters.

My reasoning is that when I'm using the cheatsheet, I know for sure the property I'm looking for, so I'll type "width", or "height". Now, the first three characters will trigger 3 searches across a huge js object (the cheatsheet.json weights 748kb on my machine). I would argue that those first 3 searches are a waste. If I'm looking for "font family" and I write "fo", many Flexbox & Grid components appear, even thought I'm certain I'm not looking for those.

This doesn't really address the big issue, why on earth is a rerender that expensive. I tried to look at how could I optimize the whole rerendering (for fun), but if I want to preserve the current search UX I did not have much luck, React memo did not help much here. I don't think it is a lost cause, but it is a bit more difficult than "just use useMemo and be done".