### PR TITLE
fix: line break and missing content in transition-properties category 

### DIFF
--- a/src/components/infoTable.tsx
+++ b/src/components/infoTable.tsx
@@ -18,7 +18,7 @@ const InfoTable = ({ table }: any) => {
             return <div className="w-6 h-6 bg-white border rounded"></div>
         }
 
-        return text;
+        return text.split('\n').map(subtext => <p>{subtext}</p>);
     };
 
     function handleClick(td: string) {

--- a/src/modules/cheatsheet.json
+++ b/src/modules/cheatsheet.json
@@ -17702,7 +17702,7 @@
                 "table": [
                     [
                         "transition",
-                        "transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;",
+                        "transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
                         ""
                     ],
                     [
@@ -17712,27 +17712,27 @@
                     ],
                     [
                         "transition-all",
-                        "transition-property: all;",
+                        "transition-property: all;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
                         ""
                     ],
                     [
                         "transition-colors",
-                        "transition-property: background-color, border-color, color, fill, stroke;",
+                        "transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
                         ""
                     ],
                     [
                         "transition-opacity",
-                        "transition-property: opacity;",
+                        "transition-property: opacity;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
                         ""
                     ],
                     [
                         "transition-shadow",
-                        "transition-property: box-shadow;",
+                        "transition-property: box-shadow;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
                         ""
                     ],
                     [
                         "transition-transform",
-                        "transition-property: transform;",
+                        "transition-property: transform;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
                         ""
                     ]
                 ]


### PR DESCRIPTION
## 1. Fix line break
Escape sequence for line break (`\n`) is added in `cheatsheet.json`, but on the web the escape sequence seems doesnt work, so I split the lines using`<p></p>` tags
Old:
![image](https://github.com/tailwindcomponents/cheatsheet/assets/57064711/bfbf5376-f4df-4ad0-9899-21df64ba2c93)
New: 
![image](https://github.com/tailwindcomponents/cheatsheet/assets/57064711/b598c53a-8aeb-4fda-b37f-67f7c3eeb719)

## 2. Add some missing properties for transition-property
Old:
![image](https://github.com/tailwindcomponents/cheatsheet/assets/57064711/252e0e36-503d-4b94-92fa-0bb19ed5bbd8)
New:
![image](https://github.com/tailwindcomponents/cheatsheet/assets/57064711/961c086e-20ed-4cfe-ae1f-1ece135462e3)

