### PR TITLE
Small optimizations

### DIFF
--- a/src/components/categories.tsx
+++ b/src/components/categories.tsx
@@ -13,7 +13,7 @@ const Categories = (props: any) => {
                     768: 2,
                     640: 1
                 }}
-                className="flex flex-wrap p-4 mx-auto mt-4 "
+                className="flex w-full flex-wrap p-4 mx-auto mt-4 "
                 columnClassName="w-auto">
                 {
                     props.cheatsheet.map((category: Category) => <CategoryComponent key={category.title} category={category} />)

--- a/src/components/categories.tsx
+++ b/src/components/categories.tsx
@@ -5,19 +5,6 @@ import CategoryComponent from './category';
 
 const Categories = (props: any) => {
     return (
-        <section className="dark:bg-gray-900 lg:pt-24">
-            <h1 className="pt-6 text-3xl font-semibold text-center text-gray-800 dark:text-gray-200">
-                Tailwind CSS Cheat Sheet
-            </h1>
-
-            <p className="max-w-6xl px-4 mx-auto mt-4 text-base text-center text-gray-500 dark:text-gray-400 md:text-lg">
-                Find quickly all the class names and CSS properties with this interactive cheat sheet. The only Tailwind CheatSheet you will ever need!
-            </p>
-
-            <p className="max-w-6xl px-4 mx-auto mt-4 text-base italic text-center text-gray-500 dark:text-gray-400 md:text-lg">
-                “Never memorize something that you can look up.” - Albert Einstein
-            </p>
-            
             <Masonry
                 breakpointCols={{
                     default: 4,
@@ -32,7 +19,6 @@ const Categories = (props: any) => {
                     props.cheatsheet.map((category: Category) => <CategoryComponent key={category.title} category={category} />)
                 }
             </Masonry>
-        </section>
     );
 }
 

--- a/src/components/category.tsx
+++ b/src/components/category.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
 import Subcategory from '../modules/models/subcategory';
 import SubcategoryComponent from './subcategory';
-import classNames from "classnames";
 
 const Category = ({ category }: any) => {
-  let hasVisibleContent = category.content.filter((el: Subcategory) => el.table.length).length > 0
   return (
-    <div className={classNames("rounded-md bg-gray-100 dark:bg-gray-800 pt-4 m-2 overflow-hidden", {
-      "bg-opacity-20": !hasVisibleContent,
-    })}>
-      <h1 className={classNames("px-3 py-2 mx-3 mb-2 font-bold text-gray-800 dark:bg-gray-700 dark:text-gray-200 tracking-wider bg-gray-200 rounded-md", {
-        "bg-opacity-10": !hasVisibleContent,
-        "text-opacity-20": !hasVisibleContent
-      })}>{category.title}</h1>
+    <div className={"rounded-md bg-gray-100 dark:bg-gray-800 pt-4 m-2 overflow-hidden"}>
+      <h1 className={"px-3 py-2 mx-3 mb-2 font-bold text-gray-800 dark:bg-gray-700 dark:text-gray-200 tracking-wider bg-gray-200 rounded-md"}>
+        {category.title}
+      </h1>
       {
         category.content.map((subcategory: Subcategory, index: Number) => {
           return subcategory.table.length > 0 && <SubcategoryComponent key={'Subcat-' + index} subcategory={subcategory} />;

--- a/src/components/infoTable.tsx
+++ b/src/components/infoTable.tsx
@@ -18,7 +18,7 @@ const InfoTable = ({ table }: any) => {
             return <div className="w-6 h-6 bg-white border rounded"></div>
         }
 
-        return text.split('\n').map(subtext => <p>{subtext}</p>);
+        return text.split('\n').map((subtext,index) => <p key={index}>{subtext}</p>);
     };
 
     function handleClick(td: string) {

--- a/src/components/infoTable.tsx
+++ b/src/components/infoTable.tsx
@@ -37,7 +37,9 @@ const InfoTable = ({ table }: any) => {
                 {
                     table.map((tr: string[], index: Number) => {
                         return (
-                            <tr key={'tr-' + index}>
+                            <tr
+                                key={'tr-' + index}
+                                className={"border-b border-gray-300 dark:border-gray-700"}>
                                 {
                                     tr.map((td: string, index: Number) => {
                                         return (
@@ -49,7 +51,7 @@ const InfoTable = ({ table }: any) => {
                                                     );
                                                 }}
                                                 key={'td-' + index}
-                                                className={classNames('cursor-copy font-mono text-xs hover:underline p-2 border-b border-gray-300 dark:border-gray-700', {
+                                                className={classNames('cursor-copy font-mono text-xs hover:underline p-2', {
                                                     'text-purple-700 dark:text-purple-300 whitespace-nowrap': index === 0,
                                                     'text-blue-700 dark:text-blue-300': index === 1,
                                                     'text-gray-500 dark:text-gray-300 text-xs': index === 2,

--- a/src/components/searchBar.tsx
+++ b/src/components/searchBar.tsx
@@ -36,7 +36,7 @@ const SearchBar = (props: any) => {
     // the screen. This little wrapper adds an artificial delay so that the
     // app doesn't block user input.
     const search = (event: any) => {
-        const text: string = event.target.value
+        const text: string = event.target.value.toLowerCase();
         if (text.length < 5) {
             clearSearch()
             searchTimeout = window.setTimeout(() => props.search(text), 300)

--- a/src/components/subcategory.tsx
+++ b/src/components/subcategory.tsx
@@ -33,16 +33,16 @@ const Subcategory = ({ subcategory }: any) => {
                 <h1 className="flex-1 text-sm tracking-wider">{subcategory.title}</h1>
                 <a
                     className="px-2 py-1 text-xs font-bold text-white uppercase transition-colors duration-300 transform bg-gray-400 rounded-md dark:bg-gray-700 hover:bg-primary dark:hover:bg-primary"
-                  href={subcategory.docs}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={onClickLink}
+                    href={subcategory.docs}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={onClickLink}
                 >
                   Docs
                 </a>
             </div>
             <div className={classNames('bg-gray-200 dark:bg-gray-700 px-4 overflow-hidden', {
-                'h-0': !isVisible
+                'hidden': !isVisible
             })}>
                 <p className="my-3 font-semibold leading-tight text-gray-800 dark:text-gray-200">{subcategory.description}</p>
                 <InfoTable table={subcategory.table} />

--- a/src/components/tagline.tsx
+++ b/src/components/tagline.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+const Tagline = () => (
+    <section className="dark:bg-gray-900 lg:pt-24">
+            <h1 className="pt-6 text-3xl font-semibold text-center text-gray-800 dark:text-gray-200">
+                Tailwind CSS Cheat Sheet
+            </h1>
+
+            <p className="max-w-6xl px-4 mx-auto mt-4 text-base text-center text-gray-500 dark:text-gray-400 md:text-lg">
+                Find quickly all the class names and CSS properties with this interactive cheat sheet. The only Tailwind CheatSheet you will ever need!
+            </p>
+
+            <p className="max-w-6xl px-4 mx-auto mt-4 text-base italic text-center text-gray-500 dark:text-gray-400 md:text-lg">
+                “Never memorize something that you can look up.” - Albert Einstein
+        </p>
+    </section>
+);
+
+export default Tagline;

--- a/src/modules/cheatsheet.json
+++ b/src/modules/cheatsheet.json
@@ -9,17 +9,15 @@
                 "table": [
                     [
                         "aspect-auto",
-                        "aspect-ratio: auto;",
-                        ""
+                        "aspect-ratio: auto;"
                     ],
                     [
                         "aspect-square",
-                        "aspect-ratio: 1 / 1;",
-                        ""
+                        "aspect-ratio: 1 / 1;"
                     ],
                     [
-                        "aspect-video", 
-                        "aspect-ratio: 16 / 9;", 
+                        "aspect-video",
+                        "aspect-ratio: 16 / 9;",
                         ""
                     ]
                 ]
@@ -32,38 +30,32 @@
                     [
                         "container",
                         "none",
-                        "width: 100%",
-                        ""
+                        "width: 100%"
                     ],
                     [
                         "",
                         "sm (640px)",
-                        "max-width: 640px;",
-                        ""
+                        "max-width: 640px;"
                     ],
                     [
                         "",
                         "md (768px)",
-                        "max-width: 768px;",
-                        ""
+                        "max-width: 768px;"
                     ],
                     [
                         "",
                         "lg (1024px)",
-                        "max-width: 1024px;",
-                        ""
+                        "max-width: 1024px;"
                     ],
                     [
                         "",
                         "xl (1280px)",
-                        "max-width: 1280px;",
-                        ""
+                        "max-width: 1280px;"
                     ],
                     [
                         "",
                         "2xl (1536px)",
-                        "max-width: 1536px;",
-                        ""
+                        "max-width: 1536px;"
                     ]
                 ]
             },
@@ -74,133 +66,107 @@
                 "table": [
                     [
                         "columns-1",
-                        "columns: 1;",
-                        ""
+                        "columns: 1;"
                     ],
                     [
                         "columns-2",
-                        "columns: 2;",
-                        ""
+                        "columns: 2;"
                     ],
                     [
                         "columns-3",
-                        "columns: 3;",
-                        ""
+                        "columns: 3;"
                     ],
                     [
                         "columns-4",
-                        "columns: 4;",
-                        ""
+                        "columns: 4;"
                     ],
                     [
                         "columns-5",
-                        "columns: 5;",
-                        ""
+                        "columns: 5;"
                     ],
                     [
                         "columns-6",
-                        "columns: 6;",
-                        ""
+                        "columns: 6;"
                     ],
                     [
                         "columns-7",
-                        "columns: 7;",
-                        ""
+                        "columns: 7;"
                     ],
                     [
                         "columns-8",
-                        "columns: 8;",
-                        ""
+                        "columns: 8;"
                     ],
                     [
                         "columns-9",
-                        "columns: 9;",
-                        ""
+                        "columns: 9;"
                     ],
                     [
                         "columns-10",
-                        "columns: 10;",
-                        ""
+                        "columns: 10;"
                     ],
                     [
                         "columns-11",
-                        "columns: 11;",
-                        ""
+                        "columns: 11;"
                     ],
                     [
                         "columns-12",
-                        "columns: 12;",
-                        ""
+                        "columns: 12;"
                     ],
                     [
                         "columns-auto",
-                        "columns: auto;",
-                        ""
+                        "columns: auto;"
                     ],
                     [
                         "columns-3xs",
-                        "columns: 16rem;",
-                        ""
+                        "columns: 16rem;"
                     ],
                     [
                         "columns-2xs",
-                        "columns: 18rem;",
-                        ""
+                        "columns: 18rem;"
                     ],
                     [
                         "columns-xs",
-                        "columns: 20rem;",
-                        ""
+                        "columns: 20rem;"
                     ],
                     [
                         "columns-sm",
-                        "columns: 24rem;",
-                        ""
+                        "columns: 24rem;"
                     ],
                     [
                         "columns-md",
-                        "columns: 28rem;",
-                        ""
+                        "columns: 28rem;"
                     ],
                     [
                         "columns-lg",
-                        "columns: 32rem;",
-                        ""
+                        "columns: 32rem;"
                     ],
                     [
                         "columns-xl",
-                        "columns: 36rem;",
-                        ""
+                        "columns: 36rem;"
                     ],
                     [
                         "columns-2xl",
-                        "columns: 42rem;",
-                        ""
+                        "columns: 42rem;"
                     ],
                     [
                         "columns-3xl",
-                        "columns: 48rem;",
-                        ""
+                        "columns: 48rem;"
                     ],
                     [
                         "columns-4xl",
-                        "columns: 56rem;",
-                        ""
+                        "columns: 56rem;"
                     ],
                     [
                         "columns-5xl",
-                        "columns: 64rem;",
-                        ""
+                        "columns: 64rem;"
                     ],
                     [
                         "columns-6xl",
-                        "columns: 72rem;",
-                        ""
+                        "columns: 72rem;"
                     ],
                     [
                         "columns-7xl",
-                        "columns: 80rem;",
-                        ""
+                        "columns: 80rem;"
                     ]
                 ]
             },
@@ -211,43 +177,35 @@
                 "table": [
                     [
                         "break-after-auto",
-                        "break-after: auto;",
-                        ""
+                        "break-after: auto;"
                     ],
                     [
                         "break-after-avoid",
-                        "break-after: avoid;",
-                        ""
+                        "break-after: avoid;"
                     ],
                     [
                         "break-after-all",
-                        "break-after: all;",
-                        ""
+                        "break-after: all;"
                     ],
                     [
                         "break-after-avoid-page",
-                        "break-after: avoid-page;",
-                        ""
+                        "break-after: avoid-page;"
                     ],
                     [
                         "break-after-page",
-                        "break-after: page;",
-                        ""
+                        "break-after: page;"
                     ],
                     [
                         "break-after-left",
-                        "break-after: left;",
-                        ""
+                        "break-after: left;"
                     ],
                     [
                         "break-after-right",
-                        "break-after: right;",
-                        ""
+                        "break-after: right;"
                     ],
                     [
                         "break-after-column",
-                        "break-after: column;",
-                        ""
+                        "break-after: column;"
                     ]
                 ]
             },
@@ -258,43 +216,35 @@
                 "table": [
                     [
                         "break-before-auto",
-                        "break-before: auto;",
-                        ""
+                        "break-before: auto;"
                     ],
                     [
                         "break-before-avoid",
-                        "break-before: avoid;",
-                        ""
+                        "break-before: avoid;"
                     ],
                     [
                         "break-before-all",
-                        "break-before: all;",
-                        ""
+                        "break-before: all;"
                     ],
                     [
                         "break-before-avoid-page",
-                        "break-before: avoid-page;",
-                        ""
+                        "break-before: avoid-page;"
                     ],
                     [
                         "break-before-page",
-                        "break-before: page;",
-                        ""
+                        "break-before: page;"
                     ],
                     [
                         "break-before-left",
-                        "break-before: left;",
-                        ""
+                        "break-before: left;"
                     ],
                     [
                         "break-before-right",
-                        "break-before: right;",
-                        ""
+                        "break-before: right;"
                     ],
                     [
                         "break-before-column",
-                        "break-before: column;",
-                        ""
+                        "break-before: column;"
                     ]
                 ]
             },
@@ -305,23 +255,19 @@
                 "table": [
                     [
                         "break-inside-auto",
-                        "break-inside: auto;",
-                        ""
+                        "break-inside: auto;"
                     ],
                     [
                         "break-inside-avoid",
-                        "break-inside: avoid;",
-                        ""
+                        "break-inside: avoid;"
                     ],
                     [
                         "break-inside-avoid-page",
-                        "break-inside: avoid-page;",
-                        ""
+                        "break-inside: avoid-page;"
                     ],
                     [
                         "break-inside-column",
-                        "break-inside: column;",
-                        ""
+                        "break-inside: column;"
                     ]
                 ]
             },
@@ -332,13 +278,11 @@
                 "table": [
                     [
                         "decoration-slice",
-                        "box-decoration-break: slice;",
-                        ""
+                        "box-decoration-break: slice;"
                     ],
                     [
                         "decoration-clone",
-                        "box-decoration-break: clone;",
-                        ""
+                        "box-decoration-break: clone;"
                     ]
                 ]
             },
@@ -349,13 +293,11 @@
                 "table": [
                     [
                         "box-border",
-                        "box-sizing: border-box;",
-                        ""
+                        "box-sizing: border-box;"
                     ],
                     [
                         "box-content",
-                        "box-sizing: content-box;",
-                        ""
+                        "box-sizing: content-box;"
                     ]
                 ]
             },
@@ -366,108 +308,87 @@
                 "table": [
                     [
                         "block",
-                        "display: block;",
-                        ""
+                        "display: block;"
                     ],
                     [
                         "inline-block",
-                        "display: inline-block;",
-                        ""
+                        "display: inline-block;"
                     ],
                     [
                         "inline",
-                        "display: inline;",
-                        ""
+                        "display: inline;"
                     ],
                     [
                         "flex",
-                        "display: flex;",
-                        ""
+                        "display: flex;"
                     ],
                     [
                         "inline-flex",
-                        "display: inline-flex;",
-                        ""
+                        "display: inline-flex;"
                     ],
                     [
                         "table",
-                        "display: table;",
-                        ""
+                        "display: table;"
                     ],
                     [
                         "inline-table",
-                        "display: inline-table;",
-                        ""
+                        "display: inline-table;"
                     ],
                     [
                         "table-caption",
-                        "display: table-caption;",
-                        ""
+                        "display: table-caption;"
                     ],
                     [
                         "table-cell",
-                        "display: table-cell;",
-                        ""
+                        "display: table-cell;"
                     ],
                     [
                         "table-column",
-                        "display: table-column;",
-                        ""
+                        "display: table-column;"
                     ],
                     [
                         "table-column-group",
-                        "display: table-column-group;",
-                        ""
+                        "display: table-column-group;"
                     ],
                     [
                         "table-footer-group",
-                        "display: table-footer-group;",
-                        ""
+                        "display: table-footer-group;"
                     ],
                     [
                         "table-header-group",
-                        "display: table-header-group;",
-                        ""
+                        "display: table-header-group;"
                     ],
                     [
                         "table-row-group",
-                        "display: table-row-group;",
-                        ""
+                        "display: table-row-group;"
                     ],
                     [
                         "table-row",
-                        "display: table-row;",
-                        ""
+                        "display: table-row;"
                     ],
                     [
                         "flow-root",
-                        "display: flow-root",
-                        ""
+                        "display: flow-root"
                     ],
                     [
                         "grid",
-                        "display: grid",
-                        ""
+                        "display: grid"
                     ],
                     [
                         "inline-grid",
-                        "display: inline-grid",
-                        ""
+                        "display: inline-grid"
                     ],
                     [
                         "contents",
-                        "display: contents;",
-                        ""
+                        "display: contents;"
                     ],
                     [
                         "list-item",
-                        "display: list-item;",
-                        ""
+                        "display: list-item;"
                     ],
                     [
                         "hidden",
-                        "display: none;",
-                        ""
+                        "display: none;"
                     ]
                 ]
             },
@@ -478,18 +399,15 @@
                 "table": [
                     [
                         "float-right",
-                        "float: right;",
-                        ""
+                        "float: right;"
                     ],
                     [
                         "float-left",
-                        "float: left;",
-                        ""
+                        "float: left;"
                     ],
                     [
                         "float-none",
-                        "float: none;",
-                        ""
+                        "float: none;"
                     ]
                 ]
             },
@@ -500,23 +418,19 @@
                 "table": [
                     [
                         "clear-left",
-                        "clear: left;",
-                        ""
+                        "clear: left;"
                     ],
                     [
                         "clear-right",
-                        "clear: right;",
-                        ""
+                        "clear: right;"
                     ],
                     [
                         "clear-both",
-                        "clear: both;",
-                        ""
+                        "clear: both;"
                     ],
                     [
                         "clear-none",
-                        "clear: none;",
-                        ""
+                        "clear: none;"
                     ]
                 ]
             },
@@ -527,13 +441,11 @@
                 "table": [
                     [
                         "isolate",
-                        "isolation: isolate;",
-                        ""
+                        "isolation: isolate;"
                     ],
                     [
                         "isolate-auto",
-                        "isolation: auto;",
-                        ""
+                        "isolation: auto;"
                     ]
                 ]
             },
@@ -544,28 +456,23 @@
                 "table": [
                     [
                         "object-contain",
-                        "object-fit: contain;",
-                        ""
+                        "object-fit: contain;"
                     ],
                     [
                         "object-cover",
-                        "object-fit: cover;",
-                        ""
+                        "object-fit: cover;"
                     ],
                     [
                         "object-fill",
-                        "object-fit: fill;",
-                        ""
+                        "object-fit: fill;"
                     ],
                     [
                         "object-none",
-                        "object-fit: none;",
-                        ""
+                        "object-fit: none;"
                     ],
                     [
                         "object-scale-down",
-                        "object-fit: scale-down;",
-                        ""
+                        "object-fit: scale-down;"
                     ]
                 ]
             },
@@ -576,48 +483,39 @@
                 "table": [
                     [
                         "object-bottom",
-                        "object-position: bottom;",
-                        ""
+                        "object-position: bottom;"
                     ],
                     [
                         "object-center",
-                        "object-position: center;",
-                        ""
+                        "object-position: center;"
                     ],
                     [
                         "object-left",
-                        "object-position: left;",
-                        ""
+                        "object-position: left;"
                     ],
                     [
                         "object-left-bottom",
-                        "object-position: left bottom;",
-                        ""
+                        "object-position: left bottom;"
                     ],
                     [
                         "object-left-top",
-                        "object-position: left top;",
-                        ""
+                        "object-position: left top;"
                     ],
                     [
                         "object-right",
-                        "object-position: right;",
-                        ""
+                        "object-position: right;"
                     ],
                     [
                         "object-right-bottom",
-                        "object-position: right bottom;",
-                        ""
+                        "object-position: right bottom;"
                     ],
                     [
                         "object-right-top",
-                        "object-position: right top;",
-                        ""
+                        "object-position: right top;"
                     ],
                     [
                         "object-top",
-                        "object-position: top;",
-                        ""
+                        "object-position: top;"
                     ]
                 ]
             },
@@ -628,73 +526,59 @@
                 "table": [
                     [
                         "overflow-auto",
-                        "overflow: auto;",
-                        ""
+                        "overflow: auto;"
                     ],
                     [
                         "overflow-x-auto",
-                        "overflow-x: auto;",
-                        ""
+                        "overflow-x: auto;"
                     ],
                     [
                         "overflow-y-auto",
-                        "overflow-y: auto;",
-                        ""
+                        "overflow-y: auto;"
                     ],
                     [
                         "overflow-hidden",
-                        "overflow: hidden;",
-                        ""
+                        "overflow: hidden;"
                     ],
                     [
                         "overflow-x-hidden",
-                        "overflow-x: hidden;",
-                        ""
+                        "overflow-x: hidden;"
                     ],
                     [
                         "overflow-y-hidden",
-                        "overflow-y: hidden;",
-                        ""
+                        "overflow-y: hidden;"
                     ],
                     [
                         "overflow-visible",
-                        "overflow: visible;",
-                        ""
+                        "overflow: visible;"
                     ],
                     [
                         "overflow-x-visible",
-                        "overflow-x: visible;",
-                        ""
+                        "overflow-x: visible;"
                     ],
                     [
                         "overflow-y-visible",
-                        "overflow-y: visible;",
-                        ""
+                        "overflow-y: visible;"
                     ],
                     [
                         "overflow-scroll",
-                        "overflow: scroll;",
-                        ""
+                        "overflow: scroll;"
                     ],
                     [
                         "overflow-x-scroll",
-                        "overflow-x: scroll;",
-                        ""
+                        "overflow-x: scroll;"
                     ],
                     [
                         "overflow-y-scroll",
-                        "overflow-y: scroll;",
-                        ""
+                        "overflow-y: scroll;"
                     ],
                     [
                         "scrolling-touch",
-                        "-webkit-overflow-scrolling: touch;",
-                        ""
+                        "-webkit-overflow-scrolling: touch;"
                     ],
                     [
                         "scrolling-auto",
-                        "-webkit-overflow-scrolling: auto;",
-                        ""
+                        "-webkit-overflow-scrolling: auto;"
                     ]
                 ]
             },
@@ -705,48 +589,39 @@
                 "table": [
                     [
                         "overscroll-auto",
-                        "overscroll-behavior: auto;",
-                        ""
+                        "overscroll-behavior: auto;"
                     ],
                     [
                         "overscroll-y-auto",
-                        "overscroll-behavior-y: auto;",
-                        ""
+                        "overscroll-behavior-y: auto;"
                     ],
                     [
                         "overscroll-x-auto",
-                        "overscroll-behavior-x: auto;",
-                        ""
+                        "overscroll-behavior-x: auto;"
                     ],
                     [
                         "overscroll-contain",
-                        "overscroll-behavior: contain;",
-                        ""
+                        "overscroll-behavior: contain;"
                     ],
                     [
                         "overscroll-y-contain",
-                        "overscroll-behavior-y: contain;",
-                        ""
+                        "overscroll-behavior-y: contain;"
                     ],
                     [
                         "overscroll-x-contain",
-                        "overscroll-behavior-x: contain;",
-                        ""
+                        "overscroll-behavior-x: contain;"
                     ],
                     [
                         "overscroll-none",
-                        "overscroll-behavior: none;",
-                        ""
+                        "overscroll-behavior: none;"
                     ],
                     [
                         "overscroll-y-none",
-                        "overscroll-behavior-y: none;",
-                        ""
+                        "overscroll-behavior-y: none;"
                     ],
                     [
                         "overscroll-x-none",
-                        "overscroll-behavior-x: none;",
-                        ""
+                        "overscroll-behavior-x: none;"
                     ]
                 ]
             },
@@ -757,28 +632,23 @@
                 "table": [
                     [
                         "static",
-                        "position: static;",
-                        ""
+                        "position: static;"
                     ],
                     [
                         "fixed",
-                        "position: fixed;",
-                        ""
+                        "position: fixed;"
                     ],
                     [
                         "absolute",
-                        "position: absolute;",
-                        ""
+                        "position: absolute;"
                     ],
                     [
                         "relative",
-                        "position: relative;",
-                        ""
+                        "position: relative;"
                     ],
                     [
                         "sticky",
-                        "position: sticky;",
-                        ""
+                        "position: sticky;"
                     ]
                 ]
             },
@@ -789,2768 +659,2215 @@
                 "table": [
                     [
                         "inset-0",
-                        "top: 0;\nright: 0;\nbottom: 0;\nleft: 0;",
-                        ""
+                        "top: 0;\nright: 0;\nbottom: 0;\nleft: 0;"
                     ],
                     [
                         "-inset-0",
-                        "top: 0;\nright: 0;\nbottom: 0;\nleft: 0;",
-                        ""
+                        "top: 0;\nright: 0;\nbottom: 0;\nleft: 0;"
                     ],
                     [
                         "inset-y-0",
-                        "top: 0;\nbottom: 0;",
-                        ""
+                        "top: 0;\nbottom: 0;"
                     ],
                     [
                         "-inset-y-0",
-                        "top: 0;\nbottom: 0;",
-                        ""
+                        "top: 0;\nbottom: 0;"
                     ],
                     [
                         "inset-x-0",
-                        "right: 0;\nleft: 0;",
-                        ""
+                        "right: 0;\nleft: 0;"
                     ],
                     [
                         "-inset-x-0",
-                        "right: 0;\nleft: 0;",
-                        ""
+                        "right: 0;\nleft: 0;"
                     ],
                     [
                         "top-0",
-                        "top: 0;",
-                        ""
+                        "top: 0;"
                     ],
                     [
                         "right-0",
-                        "right: 0;",
-                        ""
+                        "right: 0;"
                     ],
                     [
                         "bottom-0",
-                        "bottom: 0;",
-                        ""
+                        "bottom: 0;"
                     ],
                     [
                         "left-0",
-                        "left: 0;",
-                        ""
+                        "left: 0;"
                     ],
                     [
                         "-top-0",
-                        "top: 0;",
-                        ""
+                        "top: 0;"
                     ],
                     [
                         "-right-0",
-                        "right: 0;",
-                        ""
+                        "right: 0;"
                     ],
                     [
                         "-bottom-0",
-                        "bottom: 0;",
-                        ""
+                        "bottom: 0;"
                     ],
                     [
                         "-left-0",
-                        "left: 0;",
-                        ""
+                        "left: 0;"
                     ],
                     [
                         "inset-0.5",
-                        "top: 0.125rem;\nright: 0.125rem;\nbottom: 0.125rem;\nleft: 0.125rem;",
-                        ""
+                        "top: 0.125rem;\nright: 0.125rem;\nbottom: 0.125rem;\nleft: 0.125rem;"
                     ],
                     [
                         "-inset-0.5",
-                        "top: -0.125rem;\nright: -0.125rem;\nbottom: -0.125rem;\nleft: -0.125rem;",
-                        ""
+                        "top: -0.125rem;\nright: -0.125rem;\nbottom: -0.125rem;\nleft: -0.125rem;"
                     ],
                     [
                         "inset-y-0.5",
-                        "top: 0.125rem;\nbottom: 0.125rem;",
-                        ""
+                        "top: 0.125rem;\nbottom: 0.125rem;"
                     ],
                     [
                         "-inset-y-0.5",
-                        "top: -0.125rem;\nbottom: -0.125rem;",
-                        ""
+                        "top: -0.125rem;\nbottom: -0.125rem;"
                     ],
                     [
                         "inset-x-0.5",
-                        "right: 0.125rem;\nleft: 0.125rem;",
-                        ""
+                        "right: 0.125rem;\nleft: 0.125rem;"
                     ],
                     [
                         "-inset-x-0.5",
-                        "right: -0.125rem;\nleft: -0.125rem;",
-                        ""
+                        "right: -0.125rem;\nleft: -0.125rem;"
                     ],
                     [
                         "top-0.5",
-                        "top: 0.125rem;",
-                        ""
+                        "top: 0.125rem;"
                     ],
                     [
                         "right-0.5",
-                        "right: 0.125rem;",
-                        ""
+                        "right: 0.125rem;"
                     ],
                     [
                         "bottom-0.5",
-                        "bottom: 0.125rem;",
-                        ""
+                        "bottom: 0.125rem;"
                     ],
                     [
                         "left-0.5",
-                        "left: 0.125rem;",
-                        ""
+                        "left: 0.125rem;"
                     ],
                     [
                         "-top-0.5",
-                        "top: -0.125rem;",
-                        ""
+                        "top: -0.125rem;"
                     ],
                     [
                         "-right-0.5",
-                        "right: -0.125rem;",
-                        ""
+                        "right: -0.125rem;"
                     ],
                     [
                         "-bottom-0.5",
-                        "bottom: -0.125rem;",
-                        ""
+                        "bottom: -0.125rem;"
                     ],
                     [
                         "-left-0.5",
-                        "left: -0.125rem;",
-                        ""
+                        "left: -0.125rem;"
                     ],
                     [
                         "inset-1",
-                        "top: 0.25rem;\nright: 0.25rem;\nbottom: 0.25rem;\nleft: 0.25rem;",
-                        ""
+                        "top: 0.25rem;\nright: 0.25rem;\nbottom: 0.25rem;\nleft: 0.25rem;"
                     ],
                     [
                         "-inset-1",
-                        "top: -0.25rem;\nright: -0.25rem;\nbottom: -0.25rem;\nleft: -0.25rem;",
-                        ""
+                        "top: -0.25rem;\nright: -0.25rem;\nbottom: -0.25rem;\nleft: -0.25rem;"
                     ],
                     [
                         "inset-y-1",
-                        "top: 0.25rem;\nbottom: 0.25rem;",
-                        ""
+                        "top: 0.25rem;\nbottom: 0.25rem;"
                     ],
                     [
                         "-inset-y-1",
-                        "top: -0.25rem;\nbottom: -0.25rem;",
-                        ""
+                        "top: -0.25rem;\nbottom: -0.25rem;"
                     ],
                     [
                         "inset-x-1",
-                        "right: 0.25rem;\nleft: 0.25rem;",
-                        ""
+                        "right: 0.25rem;\nleft: 0.25rem;"
                     ],
                     [
                         "-inset-x-1",
-                        "right: -0.25rem;\nleft: -0.25rem;",
-                        ""
+                        "right: -0.25rem;\nleft: -0.25rem;"
                     ],
                     [
                         "top-1",
-                        "top: 0.25rem;",
-                        ""
+                        "top: 0.25rem;"
                     ],
                     [
                         "right-1",
-                        "right: 0.25rem;",
-                        ""
+                        "right: 0.25rem;"
                     ],
                     [
                         "bottom-1",
-                        "bottom: 0.25rem;",
-                        ""
+                        "bottom: 0.25rem;"
                     ],
                     [
                         "left-1",
-                        "left: 0.25rem;",
-                        ""
+                        "left: 0.25rem;"
                     ],
                     [
                         "-top-1",
-                        "top: -0.25rem;",
-                        ""
+                        "top: -0.25rem;"
                     ],
                     [
                         "-right-1",
-                        "right: -0.25rem;",
-                        ""
+                        "right: -0.25rem;"
                     ],
                     [
                         "-bottom-1",
-                        "bottom: -0.25rem;",
-                        ""
+                        "bottom: -0.25rem;"
                     ],
                     [
                         "-left-1",
-                        "left: -0.25rem;",
-                        ""
+                        "left: -0.25rem;"
                     ],
                     [
                         "inset-1.5",
-                        "top: 0.375rem;\nright: 0.375rem;\nbottom: 0.375rem;\nleft: 0.375rem;",
-                        ""
+                        "top: 0.375rem;\nright: 0.375rem;\nbottom: 0.375rem;\nleft: 0.375rem;"
                     ],
                     [
                         "-inset-1.5",
-                        "top: -0.375rem;\nright: -0.375rem;\nbottom: -0.375rem;\nleft: -0.375rem;",
-                        ""
+                        "top: -0.375rem;\nright: -0.375rem;\nbottom: -0.375rem;\nleft: -0.375rem;"
                     ],
                     [
                         "inset-y-1.5",
-                        "top: 0.375rem;\nbottom: 0.375rem;",
-                        ""
+                        "top: 0.375rem;\nbottom: 0.375rem;"
                     ],
                     [
                         "-inset-y-1.5",
-                        "top: -0.375rem;\nbottom: -0.375rem;",
-                        ""
+                        "top: -0.375rem;\nbottom: -0.375rem;"
                     ],
                     [
                         "inset-x-1.5",
-                        "right: 0.375rem;\nleft: 0.375rem;",
-                        ""
+                        "right: 0.375rem;\nleft: 0.375rem;"
                     ],
                     [
                         "-inset-x-1.5",
-                        "right: -0.375rem;\nleft: -0.375rem;",
-                        ""
+                        "right: -0.375rem;\nleft: -0.375rem;"
                     ],
                     [
                         "top-1.5",
-                        "top: 0.375rem;",
-                        ""
+                        "top: 0.375rem;"
                     ],
                     [
                         "right-1.5",
-                        "right: 0.375rem;",
-                        ""
+                        "right: 0.375rem;"
                     ],
                     [
                         "bottom-1.5",
-                        "bottom: 0.375rem;",
-                        ""
+                        "bottom: 0.375rem;"
                     ],
                     [
                         "left-1.5",
-                        "left: 0.375rem;",
-                        ""
+                        "left: 0.375rem;"
                     ],
                     [
                         "-top-1.5",
-                        "top: -0.375rem;",
-                        ""
+                        "top: -0.375rem;"
                     ],
                     [
                         "-right-1.5",
-                        "right: -0.375rem;",
-                        ""
+                        "right: -0.375rem;"
                     ],
                     [
                         "-bottom-1.5",
-                        "bottom: -0.375rem;",
-                        ""
+                        "bottom: -0.375rem;"
                     ],
                     [
                         "-left-1.5",
-                        "left: -0.375rem;",
-                        ""
+                        "left: -0.375rem;"
                     ],
                     [
                         "inset-2",
-                        "top: 0.5rem;\nright: 0.5rem;\nbottom: 0.5rem;\nleft: 0.5rem;",
-                        ""
+                        "top: 0.5rem;\nright: 0.5rem;\nbottom: 0.5rem;\nleft: 0.5rem;"
                     ],
                     [
                         "-inset-2",
-                        "top: -0.5rem;\nright: -0.5rem;\nbottom: -0.5rem;\nleft: -0.5rem;",
-                        ""
+                        "top: -0.5rem;\nright: -0.5rem;\nbottom: -0.5rem;\nleft: -0.5rem;"
                     ],
                     [
                         "inset-y-2",
-                        "top: 0.5rem;\nbottom: 0.5rem;",
-                        ""
+                        "top: 0.5rem;\nbottom: 0.5rem;"
                     ],
                     [
                         "-inset-y-2",
-                        "top: -0.5rem;\nbottom: -0.5rem;",
-                        ""
+                        "top: -0.5rem;\nbottom: -0.5rem;"
                     ],
                     [
                         "inset-x-2",
-                        "right: 0.5rem;\nleft: 0.5rem;",
-                        ""
+                        "right: 0.5rem;\nleft: 0.5rem;"
                     ],
                     [
                         "-inset-x-2",
-                        "right: -0.5rem;\nleft: -0.5rem;",
-                        ""
+                        "right: -0.5rem;\nleft: -0.5rem;"
                     ],
                     [
                         "top-2",
-                        "top: 0.5rem;",
-                        ""
+                        "top: 0.5rem;"
                     ],
                     [
                         "right-2",
-                        "right: 0.5rem;",
-                        ""
+                        "right: 0.5rem;"
                     ],
                     [
                         "bottom-2",
-                        "bottom: 0.5rem;",
-                        ""
+                        "bottom: 0.5rem;"
                     ],
                     [
                         "left-2",
-                        "left: 0.5rem;",
-                        ""
+                        "left: 0.5rem;"
                     ],
                     [
                         "-top-2",
-                        "top: -0.5rem;",
-                        ""
+                        "top: -0.5rem;"
                     ],
                     [
                         "-right-2",
-                        "right: -0.5rem;",
-                        ""
+                        "right: -0.5rem;"
                     ],
                     [
                         "-bottom-2",
-                        "bottom: -0.5rem;",
-                        ""
+                        "bottom: -0.5rem;"
                     ],
                     [
                         "-left-2",
-                        "left: -0.5rem;",
-                        ""
+                        "left: -0.5rem;"
                     ],
                     [
                         "inset-2.5",
-                        "top: 0.625rem;\nright: 0.625rem;\nbottom: 0.625rem;\nleft: 0.625rem;",
-                        ""
+                        "top: 0.625rem;\nright: 0.625rem;\nbottom: 0.625rem;\nleft: 0.625rem;"
                     ],
                     [
                         "-inset-2.5",
-                        "top: -0.625rem;\nright: -0.625rem;\nbottom: -0.625rem;\nleft: -0.625rem;",
-                        ""
+                        "top: -0.625rem;\nright: -0.625rem;\nbottom: -0.625rem;\nleft: -0.625rem;"
                     ],
                     [
                         "inset-y-2.5",
-                        "top: 0.625rem;\nbottom: 0.625rem;",
-                        ""
+                        "top: 0.625rem;\nbottom: 0.625rem;"
                     ],
                     [
                         "-inset-y-2.5",
-                        "top: -0.625rem;\nbottom: -0.625rem;",
-                        ""
+                        "top: -0.625rem;\nbottom: -0.625rem;"
                     ],
                     [
                         "inset-x-2.5",
-                        "right: 0.625rem;\nleft: 0.625rem;",
-                        ""
+                        "right: 0.625rem;\nleft: 0.625rem;"
                     ],
                     [
                         "-inset-x-2.5",
-                        "right: -0.625rem;\nleft: -0.625rem;",
-                        ""
+                        "right: -0.625rem;\nleft: -0.625rem;"
                     ],
                     [
                         "top-2.5",
-                        "top: 0.625rem;",
-                        ""
+                        "top: 0.625rem;"
                     ],
                     [
                         "right-2.5",
-                        "right: 0.625rem;",
-                        ""
+                        "right: 0.625rem;"
                     ],
                     [
                         "bottom-2.5",
-                        "bottom: 0.625rem;",
-                        ""
+                        "bottom: 0.625rem;"
                     ],
                     [
                         "left-2.5",
-                        "left: 0.625rem;",
-                        ""
+                        "left: 0.625rem;"
                     ],
                     [
                         "-top-2.5",
-                        "top: -0.625rem;",
-                        ""
+                        "top: -0.625rem;"
                     ],
                     [
                         "-right-2.5",
-                        "right: -0.625rem;",
-                        ""
+                        "right: -0.625rem;"
                     ],
                     [
                         "-bottom-2.5",
-                        "bottom: -0.625rem;",
-                        ""
+                        "bottom: -0.625rem;"
                     ],
                     [
                         "-left-2.5",
-                        "left: -0.625rem;",
-                        ""
+                        "left: -0.625rem;"
                     ],
                     [
                         "inset-3",
-                        "top: 0.75rem;\nright: 0.75rem;\nbottom: 0.75rem;\nleft: 0.75rem;",
-                        ""
+                        "top: 0.75rem;\nright: 0.75rem;\nbottom: 0.75rem;\nleft: 0.75rem;"
                     ],
                     [
                         "-inset-3",
-                        "top: -0.75rem;\nright: -0.75rem;\nbottom: -0.75rem;\nleft: -0.75rem;",
-                        ""
+                        "top: -0.75rem;\nright: -0.75rem;\nbottom: -0.75rem;\nleft: -0.75rem;"
                     ],
                     [
                         "inset-y-3",
-                        "top: 0.75rem;\nbottom: 0.75rem;",
-                        ""
+                        "top: 0.75rem;\nbottom: 0.75rem;"
                     ],
                     [
                         "-inset-y-3",
-                        "top: -0.75rem;\nbottom: -0.75rem;",
-                        ""
+                        "top: -0.75rem;\nbottom: -0.75rem;"
                     ],
                     [
                         "inset-x-3",
-                        "right: 0.75rem;\nleft: 0.75rem;",
-                        ""
+                        "right: 0.75rem;\nleft: 0.75rem;"
                     ],
                     [
                         "-inset-x-3",
-                        "right: -0.75rem;\nleft: -0.75rem;",
-                        ""
+                        "right: -0.75rem;\nleft: -0.75rem;"
                     ],
                     [
                         "top-3",
-                        "top: 0.75rem;",
-                        ""
+                        "top: 0.75rem;"
                     ],
                     [
                         "right-3",
-                        "right: 0.75rem;",
-                        ""
+                        "right: 0.75rem;"
                     ],
                     [
                         "bottom-3",
-                        "bottom: 0.75rem;",
-                        ""
+                        "bottom: 0.75rem;"
                     ],
                     [
                         "left-3",
-                        "left: 0.75rem;",
-                        ""
+                        "left: 0.75rem;"
                     ],
                     [
                         "-top-3",
-                        "top: -0.75rem;",
-                        ""
+                        "top: -0.75rem;"
                     ],
                     [
                         "-right-3",
-                        "right: -0.75rem;",
-                        ""
+                        "right: -0.75rem;"
                     ],
                     [
                         "-bottom-3",
-                        "bottom: -0.75rem;",
-                        ""
+                        "bottom: -0.75rem;"
                     ],
                     [
                         "-left-3",
-                        "left: -0.75rem;",
-                        ""
+                        "left: -0.75rem;"
                     ],
                     [
                         "inset-3.5",
-                        "top: 0.875rem;\nright: 0.875rem;\nbottom: 0.875rem;\nleft: 0.875rem;",
-                        ""
+                        "top: 0.875rem;\nright: 0.875rem;\nbottom: 0.875rem;\nleft: 0.875rem;"
                     ],
                     [
                         "-inset-3.5",
-                        "top: -0.875rem;\nright: -0.875rem;\nbottom: -0.875rem;\nleft: -0.875rem;",
-                        ""
+                        "top: -0.875rem;\nright: -0.875rem;\nbottom: -0.875rem;\nleft: -0.875rem;"
                     ],
                     [
                         "inset-y-3.5",
-                        "top: 0.875rem;\nbottom: 0.875rem;",
-                        ""
+                        "top: 0.875rem;\nbottom: 0.875rem;"
                     ],
                     [
                         "-inset-y-3.5",
-                        "top: -0.875rem;\nbottom: -0.875rem;",
-                        ""
+                        "top: -0.875rem;\nbottom: -0.875rem;"
                     ],
                     [
                         "inset-x-3.5",
-                        "right: 0.875rem;\nleft: 0.875rem;",
-                        ""
+                        "right: 0.875rem;\nleft: 0.875rem;"
                     ],
                     [
                         "-inset-x-3.5",
-                        "right: -0.875rem;\nleft: -0.875rem;",
-                        ""
+                        "right: -0.875rem;\nleft: -0.875rem;"
                     ],
                     [
                         "top-3.5",
-                        "top: 0.875rem;",
-                        ""
+                        "top: 0.875rem;"
                     ],
                     [
                         "right-3.5",
-                        "right: 0.875rem;",
-                        ""
+                        "right: 0.875rem;"
                     ],
                     [
                         "bottom-3.5",
-                        "bottom: 0.875rem;",
-                        ""
+                        "bottom: 0.875rem;"
                     ],
                     [
                         "left-3.5",
-                        "left: 0.875rem;",
-                        ""
+                        "left: 0.875rem;"
                     ],
                     [
                         "-top-3.5",
-                        "top: -0.875rem;",
-                        ""
+                        "top: -0.875rem;"
                     ],
                     [
                         "-right-3.5",
-                        "right: -0.875rem;",
-                        ""
+                        "right: -0.875rem;"
                     ],
                     [
                         "-bottom-3.5",
-                        "bottom: -0.875rem;",
-                        ""
+                        "bottom: -0.875rem;"
                     ],
                     [
                         "-left-3.5",
-                        "left: -0.875rem;",
-                        ""
+                        "left: -0.875rem;"
                     ],
                     [
                         "inset-4",
-                        "top: 1rem;\nright: 1rem;\nbottom: 1rem;\nleft: 1rem;",
-                        ""
+                        "top: 1rem;\nright: 1rem;\nbottom: 1rem;\nleft: 1rem;"
                     ],
                     [
                         "-inset-4",
-                        "top: -1rem;\nright: -1rem;\nbottom: -1rem;\nleft: -1rem;",
-                        ""
+                        "top: -1rem;\nright: -1rem;\nbottom: -1rem;\nleft: -1rem;"
                     ],
                     [
                         "inset-y-4",
-                        "top: 1rem;\nbottom: 1rem;",
-                        ""
+                        "top: 1rem;\nbottom: 1rem;"
                     ],
                     [
                         "-inset-y-4",
-                        "top: -1rem;\nbottom: -1rem;",
-                        ""
+                        "top: -1rem;\nbottom: -1rem;"
                     ],
                     [
                         "inset-x-4",
-                        "right: 1rem;\nleft: 1rem;",
-                        ""
+                        "right: 1rem;\nleft: 1rem;"
                     ],
                     [
                         "-inset-x-4",
-                        "right: -1rem;\nleft: -1rem;",
-                        ""
+                        "right: -1rem;\nleft: -1rem;"
                     ],
                     [
                         "top-4",
-                        "top: 1rem;",
-                        ""
+                        "top: 1rem;"
                     ],
                     [
                         "right-4",
-                        "right: 1rem;",
-                        ""
+                        "right: 1rem;"
                     ],
                     [
                         "bottom-4",
-                        "bottom: 1rem;",
-                        ""
+                        "bottom: 1rem;"
                     ],
                     [
                         "left-4",
-                        "left: 1rem;",
-                        ""
+                        "left: 1rem;"
                     ],
                     [
                         "-top-4",
-                        "top: -1rem;",
-                        ""
+                        "top: -1rem;"
                     ],
                     [
                         "-right-4",
-                        "right: -1rem;",
-                        ""
+                        "right: -1rem;"
                     ],
                     [
                         "-bottom-4",
-                        "bottom: -1rem;",
-                        ""
+                        "bottom: -1rem;"
                     ],
                     [
                         "-left-4",
-                        "left: -1rem;",
-                        ""
+                        "left: -1rem;"
                     ],
                     [
                         "inset-5",
-                        "top: 1.25rem;\nright: 1.25rem;\nbottom: 1.25rem;\nleft: 1.25rem;",
-                        ""
+                        "top: 1.25rem;\nright: 1.25rem;\nbottom: 1.25rem;\nleft: 1.25rem;"
                     ],
                     [
                         "-inset-5",
-                        "top: -1.25rem;\nright: -1.25rem;\nbottom: -1.25rem;\nleft: -1.25rem;",
-                        ""
+                        "top: -1.25rem;\nright: -1.25rem;\nbottom: -1.25rem;\nleft: -1.25rem;"
                     ],
                     [
                         "inset-y-5",
-                        "top: 1.25rem;\nbottom: 1.25rem;",
-                        ""
+                        "top: 1.25rem;\nbottom: 1.25rem;"
                     ],
                     [
                         "-inset-y-5",
-                        "top: -1.25rem;\nbottom: -1.25rem;",
-                        ""
+                        "top: -1.25rem;\nbottom: -1.25rem;"
                     ],
                     [
                         "inset-x-5",
-                        "right: 1.25rem;\nleft: 1.25rem;",
-                        ""
+                        "right: 1.25rem;\nleft: 1.25rem;"
                     ],
                     [
                         "-inset-x-5",
-                        "right: -1.25rem;\nleft: -1.25rem;",
-                        ""
+                        "right: -1.25rem;\nleft: -1.25rem;"
                     ],
                     [
                         "top-5",
-                        "top: 1.25rem;",
-                        ""
+                        "top: 1.25rem;"
                     ],
                     [
                         "right-5",
-                        "right: 1.25rem;",
-                        ""
+                        "right: 1.25rem;"
                     ],
                     [
                         "bottom-5",
-                        "bottom: 1.25rem;",
-                        ""
+                        "bottom: 1.25rem;"
                     ],
                     [
                         "left-5",
-                        "left: 1.25rem;",
-                        ""
+                        "left: 1.25rem;"
                     ],
                     [
                         "-top-5",
-                        "top: -1.25rem;",
-                        ""
+                        "top: -1.25rem;"
                     ],
                     [
                         "-right-5",
-                        "right: -1.25rem;",
-                        ""
+                        "right: -1.25rem;"
                     ],
                     [
                         "-bottom-5",
-                        "bottom: -1.25rem;",
-                        ""
+                        "bottom: -1.25rem;"
                     ],
                     [
                         "-left-5",
-                        "left: -1.25rem;",
-                        ""
+                        "left: -1.25rem;"
                     ],
                     [
                         "inset-6",
-                        "top: 1.5rem;\nright: 1.5rem;\nbottom: 1.5rem;\nleft: 1.5rem;",
-                        ""
+                        "top: 1.5rem;\nright: 1.5rem;\nbottom: 1.5rem;\nleft: 1.5rem;"
                     ],
                     [
                         "-inset-6",
-                        "top: -1.5rem;\nright: -1.5rem;\nbottom: -1.5rem;\nleft: -1.5rem;",
-                        ""
+                        "top: -1.5rem;\nright: -1.5rem;\nbottom: -1.5rem;\nleft: -1.5rem;"
                     ],
                     [
                         "inset-y-6",
-                        "top: 1.5rem;\nbottom: 1.5rem;",
-                        ""
+                        "top: 1.5rem;\nbottom: 1.5rem;"
                     ],
                     [
                         "-inset-y-6",
-                        "top: -1.5rem;\nbottom: -1.5rem;",
-                        ""
+                        "top: -1.5rem;\nbottom: -1.5rem;"
                     ],
                     [
                         "inset-x-6",
-                        "right: 1.5rem;\nleft: 1.5rem;",
-                        ""
+                        "right: 1.5rem;\nleft: 1.5rem;"
                     ],
                     [
                         "-inset-x-6",
-                        "right: -1.5rem;\nleft: -1.5rem;",
-                        ""
+                        "right: -1.5rem;\nleft: -1.5rem;"
                     ],
                     [
                         "top-6",
-                        "top: 1.5rem;",
-                        ""
+                        "top: 1.5rem;"
                     ],
                     [
                         "right-6",
-                        "right: 1.5rem;",
-                        ""
+                        "right: 1.5rem;"
                     ],
                     [
                         "bottom-6",
-                        "bottom: 1.5rem;",
-                        ""
+                        "bottom: 1.5rem;"
                     ],
                     [
                         "left-6",
-                        "left: 1.5rem;",
-                        ""
+                        "left: 1.5rem;"
                     ],
                     [
                         "-top-6",
-                        "top: -1.5rem;",
-                        ""
+                        "top: -1.5rem;"
                     ],
                     [
                         "-right-6",
-                        "right: -1.5rem;",
-                        ""
+                        "right: -1.5rem;"
                     ],
                     [
                         "-bottom-6",
-                        "bottom: -1.5rem;",
-                        ""
+                        "bottom: -1.5rem;"
                     ],
                     [
                         "-left-6",
-                        "left: -1.5rem;",
-                        ""
+                        "left: -1.5rem;"
                     ],
                     [
                         "inset-7",
-                        "top: 1.75rem;\nright: 1.75rem;\nbottom: 1.75rem;\nleft: 1.75rem;",
-                        ""
+                        "top: 1.75rem;\nright: 1.75rem;\nbottom: 1.75rem;\nleft: 1.75rem;"
                     ],
                     [
                         "-inset-7",
-                        "top: -1.75rem;\nright: -1.75rem;\nbottom: -1.75rem;\nleft: -1.75rem;",
-                        ""
+                        "top: -1.75rem;\nright: -1.75rem;\nbottom: -1.75rem;\nleft: -1.75rem;"
                     ],
                     [
                         "inset-y-7",
-                        "top: 1.75rem;\nbottom: 1.75rem;",
-                        ""
+                        "top: 1.75rem;\nbottom: 1.75rem;"
                     ],
                     [
                         "-inset-y-7",
-                        "top: -1.75rem;\nbottom: -1.75rem;",
-                        ""
+                        "top: -1.75rem;\nbottom: -1.75rem;"
                     ],
                     [
                         "inset-x-7",
-                        "right: 1.75rem;\nleft: 1.75rem;",
-                        ""
+                        "right: 1.75rem;\nleft: 1.75rem;"
                     ],
                     [
                         "-inset-x-7",
-                        "right: -1.75rem;\nleft: -1.75rem;",
-                        ""
+                        "right: -1.75rem;\nleft: -1.75rem;"
                     ],
                     [
                         "top-7",
-                        "top: 1.75rem;",
-                        ""
+                        "top: 1.75rem;"
                     ],
                     [
                         "right-7",
-                        "right: 1.75rem;",
-                        ""
+                        "right: 1.75rem;"
                     ],
                     [
                         "bottom-7",
-                        "bottom: 1.75rem;",
-                        ""
+                        "bottom: 1.75rem;"
                     ],
                     [
                         "left-7",
-                        "left: 1.75rem;",
-                        ""
+                        "left: 1.75rem;"
                     ],
                     [
                         "-top-7",
-                        "top: -1.75rem;",
-                        ""
+                        "top: -1.75rem;"
                     ],
                     [
                         "-right-7",
-                        "right: -1.75rem;",
-                        ""
+                        "right: -1.75rem;"
                     ],
                     [
                         "-bottom-7",
-                        "bottom: -1.75rem;",
-                        ""
+                        "bottom: -1.75rem;"
                     ],
                     [
                         "-left-7",
-                        "left: -1.75rem;",
-                        ""
+                        "left: -1.75rem;"
                     ],
                     [
                         "inset-8",
-                        "top: 2rem;\nright: 2rem;\nbottom: 2rem;\nleft: 2rem;",
-                        ""
+                        "top: 2rem;\nright: 2rem;\nbottom: 2rem;\nleft: 2rem;"
                     ],
                     [
                         "-inset-8",
-                        "top: -2rem;\nright: -2rem;\nbottom: -2rem;\nleft: -2rem;",
-                        ""
+                        "top: -2rem;\nright: -2rem;\nbottom: -2rem;\nleft: -2rem;"
                     ],
                     [
                         "inset-y-8",
-                        "top: 2rem;\nbottom: 2rem;",
-                        ""
+                        "top: 2rem;\nbottom: 2rem;"
                     ],
                     [
                         "-inset-y-8",
-                        "top: -2rem;\nbottom: -2rem;",
-                        ""
+                        "top: -2rem;\nbottom: -2rem;"
                     ],
                     [
                         "inset-x-8",
-                        "right: 2rem;\nleft: 2rem;",
-                        ""
+                        "right: 2rem;\nleft: 2rem;"
                     ],
                     [
                         "-inset-x-8",
-                        "right: -2rem;\nleft: -2rem;",
-                        ""
+                        "right: -2rem;\nleft: -2rem;"
                     ],
                     [
                         "top-8",
-                        "top: 2rem;",
-                        ""
+                        "top: 2rem;"
                     ],
                     [
                         "right-8",
-                        "right: 2rem;",
-                        ""
+                        "right: 2rem;"
                     ],
                     [
                         "bottom-8",
-                        "bottom: 2rem;",
-                        ""
+                        "bottom: 2rem;"
                     ],
                     [
                         "left-8",
-                        "left: 2rem;",
-                        ""
+                        "left: 2rem;"
                     ],
                     [
                         "-top-8",
-                        "top: -2rem;",
-                        ""
+                        "top: -2rem;"
                     ],
                     [
                         "-right-8",
-                        "right: -2rem;",
-                        ""
+                        "right: -2rem;"
                     ],
                     [
                         "-bottom-8",
-                        "bottom: -2rem;",
-                        ""
+                        "bottom: -2rem;"
                     ],
                     [
                         "-left-8",
-                        "left: -2rem;",
-                        ""
+                        "left: -2rem;"
                     ],
                     [
                         "inset-9",
-                        "top: 2.25rem;\nright: 2.25rem;\nbottom: 2.25rem;\nleft: 2.25rem;",
-                        ""
+                        "top: 2.25rem;\nright: 2.25rem;\nbottom: 2.25rem;\nleft: 2.25rem;"
                     ],
                     [
                         "-inset-9",
-                        "top: -2.25rem;\nright: -2.25rem;\nbottom: -2.25rem;\nleft: -2.25rem;",
-                        ""
+                        "top: -2.25rem;\nright: -2.25rem;\nbottom: -2.25rem;\nleft: -2.25rem;"
                     ],
                     [
                         "inset-y-9",
-                        "top: 2.25rem;\nbottom: 2.25rem;",
-                        ""
+                        "top: 2.25rem;\nbottom: 2.25rem;"
                     ],
                     [
                         "-inset-y-9",
-                        "top: -2.25rem;\nbottom: -2.25rem;",
-                        ""
+                        "top: -2.25rem;\nbottom: -2.25rem;"
                     ],
                     [
                         "inset-x-9",
-                        "right: 2.25rem;\nleft: 2.25rem;",
-                        ""
+                        "right: 2.25rem;\nleft: 2.25rem;"
                     ],
                     [
                         "-inset-x-9",
-                        "right: -2.25rem;\nleft: -2.25rem;",
-                        ""
+                        "right: -2.25rem;\nleft: -2.25rem;"
                     ],
                     [
                         "top-9",
-                        "top: 2.25rem;",
-                        ""
+                        "top: 2.25rem;"
                     ],
                     [
                         "right-9",
-                        "right: 2.25rem;",
-                        ""
+                        "right: 2.25rem;"
                     ],
                     [
                         "bottom-9",
-                        "bottom: 2.25rem;",
-                        ""
+                        "bottom: 2.25rem;"
                     ],
                     [
                         "left-9",
-                        "left: 2.25rem;",
-                        ""
+                        "left: 2.25rem;"
                     ],
                     [
                         "-top-9",
-                        "top: -2.25rem;",
-                        ""
+                        "top: -2.25rem;"
                     ],
                     [
                         "-right-9",
-                        "right: -2.25rem;",
-                        ""
+                        "right: -2.25rem;"
                     ],
                     [
                         "-bottom-9",
-                        "bottom: -2.25rem;",
-                        ""
+                        "bottom: -2.25rem;"
                     ],
                     [
                         "-left-9",
-                        "left: -2.25rem;",
-                        ""
+                        "left: -2.25rem;"
                     ],
                     [
                         "inset-10",
-                        "top: 2.5rem;\nright: 2.5rem;\nbottom: 2.5rem;\nleft: 2.5rem;",
-                        ""
+                        "top: 2.5rem;\nright: 2.5rem;\nbottom: 2.5rem;\nleft: 2.5rem;"
                     ],
                     [
                         "-inset-10",
-                        "top: -2.5rem;\nright: -2.5rem;\nbottom: -2.5rem;\nleft: -2.5rem;",
-                        ""
+                        "top: -2.5rem;\nright: -2.5rem;\nbottom: -2.5rem;\nleft: -2.5rem;"
                     ],
                     [
                         "inset-y-10",
-                        "top: 2.5rem;\nbottom: 2.5rem;",
-                        ""
+                        "top: 2.5rem;\nbottom: 2.5rem;"
                     ],
                     [
                         "-inset-y-10",
-                        "top: -2.5rem;\nbottom: -2.5rem;",
-                        ""
+                        "top: -2.5rem;\nbottom: -2.5rem;"
                     ],
                     [
                         "inset-x-10",
-                        "right: 2.5rem;\nleft: 2.5rem;",
-                        ""
+                        "right: 2.5rem;\nleft: 2.5rem;"
                     ],
                     [
                         "-inset-x-10",
-                        "right: -2.5rem;\nleft: -2.5rem;",
-                        ""
+                        "right: -2.5rem;\nleft: -2.5rem;"
                     ],
                     [
                         "top-10",
-                        "top: 2.5rem;",
-                        ""
+                        "top: 2.5rem;"
                     ],
                     [
                         "right-10",
-                        "right: 2.5rem;",
-                        ""
+                        "right: 2.5rem;"
                     ],
                     [
                         "bottom-10",
-                        "bottom: 2.5rem;",
-                        ""
+                        "bottom: 2.5rem;"
                     ],
                     [
                         "left-10",
-                        "left: 2.5rem;",
-                        ""
+                        "left: 2.5rem;"
                     ],
                     [
                         "-top-10",
-                        "top: -2.5rem;",
-                        ""
+                        "top: -2.5rem;"
                     ],
                     [
                         "-right-10",
-                        "right: -2.5rem;",
-                        ""
+                        "right: -2.5rem;"
                     ],
                     [
                         "-bottom-10",
-                        "bottom: -2.5rem;",
-                        ""
+                        "bottom: -2.5rem;"
                     ],
                     [
                         "-left-10",
-                        "left: -2.5rem;",
-                        ""
+                        "left: -2.5rem;"
                     ],
                     [
                         "inset-11",
-                        "top: 2.75rem;\nright: 2.75rem;\nbottom: 2.75rem;\nleft: 2.75rem;",
-                        ""
+                        "top: 2.75rem;\nright: 2.75rem;\nbottom: 2.75rem;\nleft: 2.75rem;"
                     ],
                     [
                         "-inset-11",
-                        "top: -2.75rem;\nright: -2.75rem;\nbottom: -2.75rem;\nleft: -2.75rem;",
-                        ""
+                        "top: -2.75rem;\nright: -2.75rem;\nbottom: -2.75rem;\nleft: -2.75rem;"
                     ],
                     [
                         "inset-y-11",
-                        "top: 2.75rem;\nbottom: 2.75rem;",
-                        ""
+                        "top: 2.75rem;\nbottom: 2.75rem;"
                     ],
                     [
                         "-inset-y-11",
-                        "top: -2.75rem;\nbottom: -2.75rem;",
-                        ""
+                        "top: -2.75rem;\nbottom: -2.75rem;"
                     ],
                     [
                         "inset-x-11",
-                        "right: 2.75rem;\nleft: 2.75rem;",
-                        ""
+                        "right: 2.75rem;\nleft: 2.75rem;"
                     ],
                     [
                         "-inset-x-11",
-                        "right: -2.75rem;\nleft: -2.75rem;",
-                        ""
+                        "right: -2.75rem;\nleft: -2.75rem;"
                     ],
                     [
                         "top-11",
-                        "top: 2.75rem;",
-                        ""
+                        "top: 2.75rem;"
                     ],
                     [
                         "right-11",
-                        "right: 2.75rem;",
-                        ""
+                        "right: 2.75rem;"
                     ],
                     [
                         "bottom-11",
-                        "bottom: 2.75rem;",
-                        ""
+                        "bottom: 2.75rem;"
                     ],
                     [
                         "left-11",
-                        "left: 2.75rem;",
-                        ""
+                        "left: 2.75rem;"
                     ],
                     [
                         "-top-11",
-                        "top: -2.75rem;",
-                        ""
+                        "top: -2.75rem;"
                     ],
                     [
                         "-right-11",
-                        "right: -2.75rem;",
-                        ""
+                        "right: -2.75rem;"
                     ],
                     [
                         "-bottom-11",
-                        "bottom: -2.75rem;",
-                        ""
+                        "bottom: -2.75rem;"
                     ],
                     [
                         "-left-11",
-                        "left: -2.75rem;",
-                        ""
+                        "left: -2.75rem;"
                     ],
                     [
                         "inset-12",
-                        "top: 3rem;\nright: 3rem;\nbottom: 3rem;\nleft: 3rem;",
-                        ""
+                        "top: 3rem;\nright: 3rem;\nbottom: 3rem;\nleft: 3rem;"
                     ],
                     [
                         "-inset-12",
-                        "top: -3rem;\nright: -3rem;\nbottom: -3rem;\nleft: -3rem;",
-                        ""
+                        "top: -3rem;\nright: -3rem;\nbottom: -3rem;\nleft: -3rem;"
                     ],
                     [
                         "inset-y-12",
-                        "top: 3rem;\nbottom: 3rem;",
-                        ""
+                        "top: 3rem;\nbottom: 3rem;"
                     ],
                     [
                         "-inset-y-12",
-                        "top: -3rem;\nbottom: -3rem;",
-                        ""
+                        "top: -3rem;\nbottom: -3rem;"
                     ],
                     [
                         "inset-x-12",
-                        "right: 3rem;\nleft: 3rem;",
-                        ""
+                        "right: 3rem;\nleft: 3rem;"
                     ],
                     [
                         "-inset-x-12",
-                        "right: -3rem;\nleft: -3rem;",
-                        ""
+                        "right: -3rem;\nleft: -3rem;"
                     ],
                     [
                         "top-12",
-                        "top: 3rem;",
-                        ""
+                        "top: 3rem;"
                     ],
                     [
                         "right-12",
-                        "right: 3rem;",
-                        ""
+                        "right: 3rem;"
                     ],
                     [
                         "bottom-12",
-                        "bottom: 3rem;",
-                        ""
+                        "bottom: 3rem;"
                     ],
                     [
                         "left-12",
-                        "left: 3rem;",
-                        ""
+                        "left: 3rem;"
                     ],
                     [
                         "-top-12",
-                        "top: -3rem;",
-                        ""
+                        "top: -3rem;"
                     ],
                     [
                         "-right-12",
-                        "right: -3rem;",
-                        ""
+                        "right: -3rem;"
                     ],
                     [
                         "-bottom-12",
-                        "bottom: -3rem;",
-                        ""
+                        "bottom: -3rem;"
                     ],
                     [
                         "-left-12",
-                        "left: -3rem;",
-                        ""
+                        "left: -3rem;"
                     ],
                     [
                         "inset-14",
-                        "top: 3.5rem;\nright: 3.5rem;\nbottom: 3.5rem;\nleft: 3.5rem;",
-                        ""
+                        "top: 3.5rem;\nright: 3.5rem;\nbottom: 3.5rem;\nleft: 3.5rem;"
                     ],
                     [
                         "-inset-14",
-                        "top: -3.5rem;\nright: -3.5rem;\nbottom: -3.5rem;\nleft: -3.5rem;",
-                        ""
+                        "top: -3.5rem;\nright: -3.5rem;\nbottom: -3.5rem;\nleft: -3.5rem;"
                     ],
                     [
                         "inset-y-14",
-                        "top: 3.5rem;\nbottom: 3.5rem;",
-                        ""
+                        "top: 3.5rem;\nbottom: 3.5rem;"
                     ],
                     [
                         "-inset-y-14",
-                        "top: -3.5rem;\nbottom: -3.5rem;",
-                        ""
+                        "top: -3.5rem;\nbottom: -3.5rem;"
                     ],
                     [
                         "inset-x-14",
-                        "right: 3.5rem;\nleft: 3.5rem;",
-                        ""
+                        "right: 3.5rem;\nleft: 3.5rem;"
                     ],
                     [
                         "-inset-x-14",
-                        "right: -3.5rem;\nleft: -3.5rem;",
-                        ""
+                        "right: -3.5rem;\nleft: -3.5rem;"
                     ],
                     [
                         "top-14",
-                        "top: 3.5rem;",
-                        ""
+                        "top: 3.5rem;"
                     ],
                     [
                         "right-14",
-                        "right: 3.5rem;",
-                        ""
+                        "right: 3.5rem;"
                     ],
                     [
                         "bottom-14",
-                        "bottom: 3.5rem;",
-                        ""
+                        "bottom: 3.5rem;"
                     ],
                     [
                         "left-14",
-                        "left: 3.5rem;",
-                        ""
+                        "left: 3.5rem;"
                     ],
                     [
                         "-top-14",
-                        "top: -3.5rem;",
-                        ""
+                        "top: -3.5rem;"
                     ],
                     [
                         "-right-14",
-                        "right: -3.5rem;",
-                        ""
+                        "right: -3.5rem;"
                     ],
                     [
                         "-bottom-14",
-                        "bottom: -3.5rem;",
-                        ""
+                        "bottom: -3.5rem;"
                     ],
                     [
                         "-left-14",
-                        "left: -3.5rem;",
-                        ""
+                        "left: -3.5rem;"
                     ],
                     [
                         "inset-16",
-                        "top: 4rem;\nright: 4rem;\nbottom: 4rem;\nleft: 4rem;",
-                        ""
+                        "top: 4rem;\nright: 4rem;\nbottom: 4rem;\nleft: 4rem;"
                     ],
                     [
                         "-inset-16",
-                        "top: -4rem;\nright: -4rem;\nbottom: -4rem;\nleft: -4rem;",
-                        ""
+                        "top: -4rem;\nright: -4rem;\nbottom: -4rem;\nleft: -4rem;"
                     ],
                     [
                         "inset-y-16",
-                        "top: 4rem;\nbottom: 4rem;",
-                        ""
+                        "top: 4rem;\nbottom: 4rem;"
                     ],
                     [
                         "-inset-y-16",
-                        "top: -4rem;\nbottom: -4rem;",
-                        ""
+                        "top: -4rem;\nbottom: -4rem;"
                     ],
                     [
                         "inset-x-16",
-                        "right: 4rem;\nleft: 4rem;",
-                        ""
+                        "right: 4rem;\nleft: 4rem;"
                     ],
                     [
                         "-inset-x-16",
-                        "right: -4rem;\nleft: -4rem;",
-                        ""
+                        "right: -4rem;\nleft: -4rem;"
                     ],
                     [
                         "top-16",
-                        "top: 4rem;",
-                        ""
+                        "top: 4rem;"
                     ],
                     [
                         "right-16",
-                        "right: 4rem;",
-                        ""
+                        "right: 4rem;"
                     ],
                     [
                         "bottom-16",
-                        "bottom: 4rem;",
-                        ""
+                        "bottom: 4rem;"
                     ],
                     [
                         "left-16",
-                        "left: 4rem;",
-                        ""
+                        "left: 4rem;"
                     ],
                     [
                         "-top-16",
-                        "top: -4rem;",
-                        ""
+                        "top: -4rem;"
                     ],
                     [
                         "-right-16",
-                        "right: -4rem;",
-                        ""
+                        "right: -4rem;"
                     ],
                     [
                         "-bottom-16",
-                        "bottom: -4rem;",
-                        ""
+                        "bottom: -4rem;"
                     ],
                     [
                         "-left-16",
-                        "left: -4rem;",
-                        ""
+                        "left: -4rem;"
                     ],
                     [
                         "inset-20",
-                        "top: 5rem;\nright: 5rem;\nbottom: 5rem;\nleft: 5rem;",
-                        ""
+                        "top: 5rem;\nright: 5rem;\nbottom: 5rem;\nleft: 5rem;"
                     ],
                     [
                         "-inset-20",
-                        "top: -5rem;\nright: -5rem;\nbottom: -5rem;\nleft: -5rem;",
-                        ""
+                        "top: -5rem;\nright: -5rem;\nbottom: -5rem;\nleft: -5rem;"
                     ],
                     [
                         "inset-y-20",
-                        "top: 5rem;\nbottom: 5rem;",
-                        ""
+                        "top: 5rem;\nbottom: 5rem;"
                     ],
                     [
                         "-inset-y-20",
-                        "top: -5rem;\nbottom: -5rem;",
-                        ""
+                        "top: -5rem;\nbottom: -5rem;"
                     ],
                     [
                         "inset-x-20",
-                        "right: 5rem;\nleft: 5rem;",
-                        ""
+                        "right: 5rem;\nleft: 5rem;"
                     ],
                     [
                         "-inset-x-20",
-                        "right: -5rem;\nleft: -5rem;",
-                        ""
+                        "right: -5rem;\nleft: -5rem;"
                     ],
                     [
                         "top-20",
-                        "top: 5rem;",
-                        ""
+                        "top: 5rem;"
                     ],
                     [
                         "right-20",
-                        "right: 5rem;",
-                        ""
+                        "right: 5rem;"
                     ],
                     [
                         "bottom-20",
-                        "bottom: 5rem;",
-                        ""
+                        "bottom: 5rem;"
                     ],
                     [
                         "left-20",
-                        "left: 5rem;",
-                        ""
+                        "left: 5rem;"
                     ],
                     [
                         "-top-20",
-                        "top: -5rem;",
-                        ""
+                        "top: -5rem;"
                     ],
                     [
                         "-right-20",
-                        "right: -5rem;",
-                        ""
+                        "right: -5rem;"
                     ],
                     [
                         "-bottom-20",
-                        "bottom: -5rem;",
-                        ""
+                        "bottom: -5rem;"
                     ],
                     [
                         "-left-20",
-                        "left: -5rem;",
-                        ""
+                        "left: -5rem;"
                     ],
                     [
                         "inset-24",
-                        "top: 6rem;\nright: 6rem;\nbottom: 6rem;\nleft: 6rem;",
-                        ""
+                        "top: 6rem;\nright: 6rem;\nbottom: 6rem;\nleft: 6rem;"
                     ],
                     [
                         "-inset-24",
-                        "top: -6rem;\nright: -6rem;\nbottom: -6rem;\nleft: -6rem;",
-                        ""
+                        "top: -6rem;\nright: -6rem;\nbottom: -6rem;\nleft: -6rem;"
                     ],
                     [
                         "inset-y-24",
-                        "top: 6rem;\nbottom: 6rem;",
-                        ""
+                        "top: 6rem;\nbottom: 6rem;"
                     ],
                     [
                         "-inset-y-24",
-                        "top: -6rem;\nbottom: -6rem;",
-                        ""
+                        "top: -6rem;\nbottom: -6rem;"
                     ],
                     [
                         "inset-x-24",
-                        "right: 6rem;\nleft: 6rem;",
-                        ""
+                        "right: 6rem;\nleft: 6rem;"
                     ],
                     [
                         "-inset-x-24",
-                        "right: -6rem;\nleft: -6rem;",
-                        ""
+                        "right: -6rem;\nleft: -6rem;"
                     ],
                     [
                         "top-24",
-                        "top: 6rem;",
-                        ""
+                        "top: 6rem;"
                     ],
                     [
                         "right-24",
-                        "right: 6rem;",
-                        ""
+                        "right: 6rem;"
                     ],
                     [
                         "bottom-24",
-                        "bottom: 6rem;",
-                        ""
+                        "bottom: 6rem;"
                     ],
                     [
                         "left-24",
-                        "left: 6rem;",
-                        ""
+                        "left: 6rem;"
                     ],
                     [
                         "-top-24",
-                        "top: -6rem;",
-                        ""
+                        "top: -6rem;"
                     ],
                     [
                         "-right-24",
-                        "right: -6rem;",
-                        ""
+                        "right: -6rem;"
                     ],
                     [
                         "-bottom-24",
-                        "bottom: -6rem;",
-                        ""
+                        "bottom: -6rem;"
                     ],
                     [
                         "-left-24",
-                        "left: -6rem;",
-                        ""
+                        "left: -6rem;"
                     ],
                     [
                         "inset-28",
-                        "top: 7rem;\nright: 7rem;\nbottom: 7rem;\nleft: 7rem;",
-                        ""
+                        "top: 7rem;\nright: 7rem;\nbottom: 7rem;\nleft: 7rem;"
                     ],
                     [
                         "-inset-28",
-                        "top: -7rem;\nright: -7rem;\nbottom: -7rem;\nleft: -7rem;",
-                        ""
+                        "top: -7rem;\nright: -7rem;\nbottom: -7rem;\nleft: -7rem;"
                     ],
                     [
                         "inset-y-28",
-                        "top: 7rem;\nbottom: 7rem;",
-                        ""
+                        "top: 7rem;\nbottom: 7rem;"
                     ],
                     [
                         "-inset-y-28",
-                        "top: -7rem;\nbottom: -7rem;",
-                        ""
+                        "top: -7rem;\nbottom: -7rem;"
                     ],
                     [
                         "inset-x-28",
-                        "right: 7rem;\nleft: 7rem;",
-                        ""
+                        "right: 7rem;\nleft: 7rem;"
                     ],
                     [
                         "-inset-x-28",
-                        "right: -7rem;\nleft: -7rem;",
-                        ""
+                        "right: -7rem;\nleft: -7rem;"
                     ],
                     [
                         "top-28",
-                        "top: 7rem;",
-                        ""
+                        "top: 7rem;"
                     ],
                     [
                         "right-28",
-                        "right: 7rem;",
-                        ""
+                        "right: 7rem;"
                     ],
                     [
                         "bottom-28",
-                        "bottom: 7rem;",
-                        ""
+                        "bottom: 7rem;"
                     ],
                     [
                         "left-28",
-                        "left: 7rem;",
-                        ""
+                        "left: 7rem;"
                     ],
                     [
                         "-top-28",
-                        "top: -7rem;",
-                        ""
+                        "top: -7rem;"
                     ],
                     [
                         "-right-28",
-                        "right: -7rem;",
-                        ""
+                        "right: -7rem;"
                     ],
                     [
                         "-bottom-28",
-                        "bottom: -7rem;",
-                        ""
+                        "bottom: -7rem;"
                     ],
                     [
                         "-left-28",
-                        "left: -7rem;",
-                        ""
+                        "left: -7rem;"
                     ],
                     [
                         "inset-32",
-                        "top: 8rem;\nright: 8rem;\nbottom: 8rem;\nleft: 8rem;",
-                        ""
+                        "top: 8rem;\nright: 8rem;\nbottom: 8rem;\nleft: 8rem;"
                     ],
                     [
                         "-inset-32",
-                        "top: -8rem;\nright: -8rem;\nbottom: -8rem;\nleft: -8rem;",
-                        ""
+                        "top: -8rem;\nright: -8rem;\nbottom: -8rem;\nleft: -8rem;"
                     ],
                     [
                         "inset-y-32",
-                        "top: 8rem;\nbottom: 8rem;",
-                        ""
+                        "top: 8rem;\nbottom: 8rem;"
                     ],
                     [
                         "-inset-y-32",
-                        "top: -8rem;\nbottom: -8rem;",
-                        ""
+                        "top: -8rem;\nbottom: -8rem;"
                     ],
                     [
                         "inset-x-32",
-                        "right: 8rem;\nleft: 8rem;",
-                        ""
+                        "right: 8rem;\nleft: 8rem;"
                     ],
                     [
                         "-inset-x-32",
-                        "right: -8rem;\nleft: -8rem;",
-                        ""
+                        "right: -8rem;\nleft: -8rem;"
                     ],
                     [
                         "top-32",
-                        "top: 8rem;",
-                        ""
+                        "top: 8rem;"
                     ],
                     [
                         "right-32",
-                        "right: 8rem;",
-                        ""
+                        "right: 8rem;"
                     ],
                     [
                         "bottom-32",
-                        "bottom: 8rem;",
-                        ""
+                        "bottom: 8rem;"
                     ],
                     [
                         "left-32",
-                        "left: 8rem;",
-                        ""
+                        "left: 8rem;"
                     ],
                     [
                         "-top-32",
-                        "top: -8rem;",
-                        ""
+                        "top: -8rem;"
                     ],
                     [
                         "-right-32",
-                        "right: -8rem;",
-                        ""
+                        "right: -8rem;"
                     ],
                     [
                         "-bottom-32",
-                        "bottom: -8rem;",
-                        ""
+                        "bottom: -8rem;"
                     ],
                     [
                         "-left-32",
-                        "left: -8rem;",
-                        ""
+                        "left: -8rem;"
                     ],
                     [
                         "inset-36",
-                        "top: 9rem;\nright: 9rem;\nbottom: 9rem;\nleft: 9rem;",
-                        ""
+                        "top: 9rem;\nright: 9rem;\nbottom: 9rem;\nleft: 9rem;"
                     ],
                     [
                         "-inset-36",
-                        "top: -9rem;\nright: -9rem;\nbottom: -9rem;\nleft: -9rem;",
-                        ""
+                        "top: -9rem;\nright: -9rem;\nbottom: -9rem;\nleft: -9rem;"
                     ],
                     [
                         "inset-y-36",
-                        "top: 9rem;\nbottom: 9rem;",
-                        ""
+                        "top: 9rem;\nbottom: 9rem;"
                     ],
                     [
                         "-inset-y-36",
-                        "top: -9rem;\nbottom: -9rem;",
-                        ""
+                        "top: -9rem;\nbottom: -9rem;"
                     ],
                     [
                         "inset-x-36",
-                        "right: 9rem;\nleft: 9rem;",
-                        ""
+                        "right: 9rem;\nleft: 9rem;"
                     ],
                     [
                         "-inset-x-36",
-                        "right: -9rem;\nleft: -9rem;",
-                        ""
+                        "right: -9rem;\nleft: -9rem;"
                     ],
                     [
                         "top-36",
-                        "top: 9rem;",
-                        ""
+                        "top: 9rem;"
                     ],
                     [
                         "right-36",
-                        "right: 9rem;",
-                        ""
+                        "right: 9rem;"
                     ],
                     [
                         "bottom-36",
-                        "bottom: 9rem;",
-                        ""
+                        "bottom: 9rem;"
                     ],
                     [
                         "left-36",
-                        "left: 9rem;",
-                        ""
+                        "left: 9rem;"
                     ],
                     [
                         "-top-36",
-                        "top: -9rem;",
-                        ""
+                        "top: -9rem;"
                     ],
                     [
                         "-right-36",
-                        "right: -9rem;",
-                        ""
+                        "right: -9rem;"
                     ],
                     [
                         "-bottom-36",
-                        "bottom: -9rem;",
-                        ""
+                        "bottom: -9rem;"
                     ],
                     [
                         "-left-36",
-                        "left: -9rem;",
-                        ""
+                        "left: -9rem;"
                     ],
                     [
                         "inset-40",
-                        "top: 10rem;\nright: 10rem;\nbottom: 10rem;\nleft: 10rem;",
-                        ""
+                        "top: 10rem;\nright: 10rem;\nbottom: 10rem;\nleft: 10rem;"
                     ],
                     [
                         "-inset-40",
-                        "top: -10rem;\nright: -10rem;\nbottom: -10rem;\nleft: -10rem;",
-                        ""
+                        "top: -10rem;\nright: -10rem;\nbottom: -10rem;\nleft: -10rem;"
                     ],
                     [
                         "inset-y-40",
-                        "top: 10rem;\nbottom: 10rem;",
-                        ""
+                        "top: 10rem;\nbottom: 10rem;"
                     ],
                     [
                         "-inset-y-40",
-                        "top: -10rem;\nbottom: -10rem;",
-                        ""
+                        "top: -10rem;\nbottom: -10rem;"
                     ],
                     [
                         "inset-x-40",
-                        "right: 10rem;\nleft: 10rem;",
-                        ""
+                        "right: 10rem;\nleft: 10rem;"
                     ],
                     [
                         "-inset-x-40",
-                        "right: -10rem;\nleft: -10rem;",
-                        ""
+                        "right: -10rem;\nleft: -10rem;"
                     ],
                     [
                         "top-40",
-                        "top: 10rem;",
-                        ""
+                        "top: 10rem;"
                     ],
                     [
                         "right-40",
-                        "right: 10rem;",
-                        ""
+                        "right: 10rem;"
                     ],
                     [
                         "bottom-40",
-                        "bottom: 10rem;",
-                        ""
+                        "bottom: 10rem;"
                     ],
                     [
                         "left-40",
-                        "left: 10rem;",
-                        ""
+                        "left: 10rem;"
                     ],
                     [
                         "-top-40",
-                        "top: -10rem;",
-                        ""
+                        "top: -10rem;"
                     ],
                     [
                         "-right-40",
-                        "right: -10rem;",
-                        ""
+                        "right: -10rem;"
                     ],
                     [
                         "-bottom-40",
-                        "bottom: -10rem;",
-                        ""
+                        "bottom: -10rem;"
                     ],
                     [
                         "-left-40",
-                        "left: -10rem;",
-                        ""
+                        "left: -10rem;"
                     ],
                     [
                         "inset-44",
-                        "top: 11rem;\nright: 11rem;\nbottom: 11rem;\nleft: 11rem;",
-                        ""
+                        "top: 11rem;\nright: 11rem;\nbottom: 11rem;\nleft: 11rem;"
                     ],
                     [
                         "-inset-44",
-                        "top: -11rem;\nright: -11rem;\nbottom: -11rem;\nleft: -11rem;",
-                        ""
+                        "top: -11rem;\nright: -11rem;\nbottom: -11rem;\nleft: -11rem;"
                     ],
                     [
                         "inset-y-44",
-                        "top: 11rem;\nbottom: 11rem;",
-                        ""
+                        "top: 11rem;\nbottom: 11rem;"
                     ],
                     [
                         "-inset-y-44",
-                        "top: -11rem;\nbottom: -11rem;",
-                        ""
+                        "top: -11rem;\nbottom: -11rem;"
                     ],
                     [
                         "inset-x-44",
-                        "right: 11rem;\nleft: 11rem;",
-                        ""
+                        "right: 11rem;\nleft: 11rem;"
                     ],
                     [
                         "-inset-x-44",
-                        "right: -11rem;\nleft: -11rem;",
-                        ""
+                        "right: -11rem;\nleft: -11rem;"
                     ],
                     [
                         "top-44",
-                        "top: 11rem;",
-                        ""
+                        "top: 11rem;"
                     ],
                     [
                         "right-44",
-                        "right: 11rem;",
-                        ""
+                        "right: 11rem;"
                     ],
                     [
                         "bottom-44",
-                        "bottom: 11rem;",
-                        ""
+                        "bottom: 11rem;"
                     ],
                     [
                         "left-44",
-                        "left: 11rem;",
-                        ""
+                        "left: 11rem;"
                     ],
                     [
                         "-top-44",
-                        "top: -11rem;",
-                        ""
+                        "top: -11rem;"
                     ],
                     [
                         "-right-44",
-                        "right: -11rem;",
-                        ""
+                        "right: -11rem;"
                     ],
                     [
                         "-bottom-44",
-                        "bottom: -11rem;",
-                        ""
+                        "bottom: -11rem;"
                     ],
                     [
                         "-left-44",
-                        "left: -11rem;",
-                        ""
+                        "left: -11rem;"
                     ],
                     [
                         "inset-48",
-                        "top: 12rem;\nright: 12rem;\nbottom: 12rem;\nleft: 12rem;",
-                        ""
+                        "top: 12rem;\nright: 12rem;\nbottom: 12rem;\nleft: 12rem;"
                     ],
                     [
                         "-inset-48",
-                        "top: -12rem;\nright: -12rem;\nbottom: -12rem;\nleft: -12rem;",
-                        ""
+                        "top: -12rem;\nright: -12rem;\nbottom: -12rem;\nleft: -12rem;"
                     ],
                     [
                         "inset-y-48",
-                        "top: 12rem;\nbottom: 12rem;",
-                        ""
+                        "top: 12rem;\nbottom: 12rem;"
                     ],
                     [
                         "-inset-y-48",
-                        "top: -12rem;\nbottom: -12rem;",
-                        ""
+                        "top: -12rem;\nbottom: -12rem;"
                     ],
                     [
                         "inset-x-48",
-                        "right: 12rem;\nleft: 12rem;",
-                        ""
+                        "right: 12rem;\nleft: 12rem;"
                     ],
                     [
                         "-inset-x-48",
-                        "right: -12rem;\nleft: -12rem;",
-                        ""
+                        "right: -12rem;\nleft: -12rem;"
                     ],
                     [
                         "top-48",
-                        "top: 12rem;",
-                        ""
+                        "top: 12rem;"
                     ],
                     [
                         "right-48",
-                        "right: 12rem;",
-                        ""
+                        "right: 12rem;"
                     ],
                     [
                         "bottom-48",
-                        "bottom: 12rem;",
-                        ""
+                        "bottom: 12rem;"
                     ],
                     [
                         "left-48",
-                        "left: 12rem;",
-                        ""
+                        "left: 12rem;"
                     ],
                     [
                         "-top-48",
-                        "top: -12rem;",
-                        ""
+                        "top: -12rem;"
                     ],
                     [
                         "-right-48",
-                        "right: -12rem;",
-                        ""
+                        "right: -12rem;"
                     ],
                     [
                         "-bottom-48",
-                        "bottom: -12rem;",
-                        ""
+                        "bottom: -12rem;"
                     ],
                     [
                         "-left-48",
-                        "left: -12rem;",
-                        ""
+                        "left: -12rem;"
                     ],
                     [
                         "inset-52",
-                        "top: 13rem;\nright: 13rem;\nbottom: 13rem;\nleft: 13rem;",
-                        ""
+                        "top: 13rem;\nright: 13rem;\nbottom: 13rem;\nleft: 13rem;"
                     ],
                     [
                         "-inset-52",
-                        "top: -13rem;\nright: -13rem;\nbottom: -13rem;\nleft: -13rem;",
-                        ""
+                        "top: -13rem;\nright: -13rem;\nbottom: -13rem;\nleft: -13rem;"
                     ],
                     [
                         "inset-y-52",
-                        "top: 13rem;\nbottom: 13rem;",
-                        ""
+                        "top: 13rem;\nbottom: 13rem;"
                     ],
                     [
                         "-inset-y-52",
-                        "top: -13rem;\nbottom: -13rem;",
-                        ""
+                        "top: -13rem;\nbottom: -13rem;"
                     ],
                     [
                         "inset-x-52",
-                        "right: 13rem;\nleft: 13rem;",
-                        ""
+                        "right: 13rem;\nleft: 13rem;"
                     ],
                     [
                         "-inset-x-52",
-                        "right: -13rem;\nleft: -13rem;",
-                        ""
+                        "right: -13rem;\nleft: -13rem;"
                     ],
                     [
                         "top-52",
-                        "top: 13rem;",
-                        ""
+                        "top: 13rem;"
                     ],
                     [
                         "right-52",
-                        "right: 13rem;",
-                        ""
+                        "right: 13rem;"
                     ],
                     [
                         "bottom-52",
-                        "bottom: 13rem;",
-                        ""
+                        "bottom: 13rem;"
                     ],
                     [
                         "left-52",
-                        "left: 13rem;",
-                        ""
+                        "left: 13rem;"
                     ],
                     [
                         "-top-52",
-                        "top: -13rem;",
-                        ""
+                        "top: -13rem;"
                     ],
                     [
                         "-right-52",
-                        "right: -13rem;",
-                        ""
+                        "right: -13rem;"
                     ],
                     [
                         "-bottom-52",
-                        "bottom: -13rem;",
-                        ""
+                        "bottom: -13rem;"
                     ],
                     [
                         "-left-52",
-                        "left: -13rem;",
-                        ""
+                        "left: -13rem;"
                     ],
                     [
                         "inset-56",
-                        "top: 14rem;\nright: 14rem;\nbottom: 14rem;\nleft: 14rem;",
-                        ""
+                        "top: 14rem;\nright: 14rem;\nbottom: 14rem;\nleft: 14rem;"
                     ],
                     [
                         "-inset-56",
-                        "top: -14rem;\nright: -14rem;\nbottom: -14rem;\nleft: -14rem;",
-                        ""
+                        "top: -14rem;\nright: -14rem;\nbottom: -14rem;\nleft: -14rem;"
                     ],
                     [
                         "inset-y-56",
-                        "top: 14rem;\nbottom: 14rem;",
-                        ""
+                        "top: 14rem;\nbottom: 14rem;"
                     ],
                     [
                         "-inset-y-56",
-                        "top: -14rem;\nbottom: -14rem;",
-                        ""
+                        "top: -14rem;\nbottom: -14rem;"
                     ],
                     [
                         "inset-x-56",
-                        "right: 14rem;\nleft: 14rem;",
-                        ""
+                        "right: 14rem;\nleft: 14rem;"
                     ],
                     [
                         "-inset-x-56",
-                        "right: -14rem;\nleft: -14rem;",
-                        ""
+                        "right: -14rem;\nleft: -14rem;"
                     ],
                     [
                         "top-56",
-                        "top: 14rem;",
-                        ""
+                        "top: 14rem;"
                     ],
                     [
                         "right-56",
-                        "right: 14rem;",
-                        ""
+                        "right: 14rem;"
                     ],
                     [
                         "bottom-56",
-                        "bottom: 14rem;",
-                        ""
+                        "bottom: 14rem;"
                     ],
                     [
                         "left-56",
-                        "left: 14rem;",
-                        ""
+                        "left: 14rem;"
                     ],
                     [
                         "-top-56",
-                        "top: -14rem;",
-                        ""
+                        "top: -14rem;"
                     ],
                     [
                         "-right-56",
-                        "right: -14rem;",
-                        ""
+                        "right: -14rem;"
                     ],
                     [
                         "-bottom-56",
-                        "bottom: -14rem;",
-                        ""
+                        "bottom: -14rem;"
                     ],
                     [
                         "-left-56",
-                        "left: -14rem;",
-                        ""
+                        "left: -14rem;"
                     ],
                     [
                         "inset-60",
-                        "top: 15rem;\nright: 15rem;\nbottom: 15rem;\nleft: 15rem;",
-                        ""
+                        "top: 15rem;\nright: 15rem;\nbottom: 15rem;\nleft: 15rem;"
                     ],
                     [
                         "-inset-60",
-                        "top: -15rem;\nright: -15rem;\nbottom: -15rem;\nleft: -15rem;",
-                        ""
+                        "top: -15rem;\nright: -15rem;\nbottom: -15rem;\nleft: -15rem;"
                     ],
                     [
                         "inset-y-60",
-                        "top: 15rem;\nbottom: 15rem;",
-                        ""
+                        "top: 15rem;\nbottom: 15rem;"
                     ],
                     [
                         "-inset-y-60",
-                        "top: -15rem;\nbottom: -15rem;",
-                        ""
+                        "top: -15rem;\nbottom: -15rem;"
                     ],
                     [
                         "inset-x-60",
-                        "right: 15rem;\nleft: 15rem;",
-                        ""
+                        "right: 15rem;\nleft: 15rem;"
                     ],
                     [
                         "-inset-x-60",
-                        "right: -15rem;\nleft: -15rem;",
-                        ""
+                        "right: -15rem;\nleft: -15rem;"
                     ],
                     [
                         "top-60",
-                        "top: 15rem;",
-                        ""
+                        "top: 15rem;"
                     ],
                     [
                         "right-60",
-                        "right: 15rem;",
-                        ""
+                        "right: 15rem;"
                     ],
                     [
                         "bottom-60",
-                        "bottom: 15rem;",
-                        ""
+                        "bottom: 15rem;"
                     ],
                     [
                         "left-60",
-                        "left: 15rem;",
-                        ""
+                        "left: 15rem;"
                     ],
                     [
                         "-top-60",
-                        "top: -15rem;",
-                        ""
+                        "top: -15rem;"
                     ],
                     [
                         "-right-60",
-                        "right: -15rem;",
-                        ""
+                        "right: -15rem;"
                     ],
                     [
                         "-bottom-60",
-                        "bottom: -15rem;",
-                        ""
+                        "bottom: -15rem;"
                     ],
                     [
                         "-left-60",
-                        "left: -15rem;",
-                        ""
+                        "left: -15rem;"
                     ],
                     [
                         "inset-64",
-                        "top: 16rem;\nright: 16rem;\nbottom: 16rem;\nleft: 16rem;",
-                        ""
+                        "top: 16rem;\nright: 16rem;\nbottom: 16rem;\nleft: 16rem;"
                     ],
                     [
                         "-inset-64",
-                        "top: -16rem;\nright: -16rem;\nbottom: -16rem;\nleft: -16rem;",
-                        ""
+                        "top: -16rem;\nright: -16rem;\nbottom: -16rem;\nleft: -16rem;"
                     ],
                     [
                         "inset-y-64",
-                        "top: 16rem;\nbottom: 16rem;",
-                        ""
+                        "top: 16rem;\nbottom: 16rem;"
                     ],
                     [
                         "-inset-y-64",
-                        "top: -16rem;\nbottom: -16rem;",
-                        ""
+                        "top: -16rem;\nbottom: -16rem;"
                     ],
                     [
                         "inset-x-64",
-                        "right: 16rem;\nleft: 16rem;",
-                        ""
+                        "right: 16rem;\nleft: 16rem;"
                     ],
                     [
                         "-inset-x-64",
-                        "right: -16rem;\nleft: -16rem;",
-                        ""
+                        "right: -16rem;\nleft: -16rem;"
                     ],
                     [
                         "top-64",
-                        "top: 16rem;",
-                        ""
+                        "top: 16rem;"
                     ],
                     [
                         "right-64",
-                        "right: 16rem;",
-                        ""
+                        "right: 16rem;"
                     ],
                     [
                         "bottom-64",
-                        "bottom: 16rem;",
-                        ""
+                        "bottom: 16rem;"
                     ],
                     [
                         "left-64",
-                        "left: 16rem;",
-                        ""
+                        "left: 16rem;"
                     ],
                     [
                         "-top-64",
-                        "top: -16rem;",
-                        ""
+                        "top: -16rem;"
                     ],
                     [
                         "-right-64",
-                        "right: -16rem;",
-                        ""
+                        "right: -16rem;"
                     ],
                     [
                         "-bottom-64",
-                        "bottom: -16rem;",
-                        ""
+                        "bottom: -16rem;"
                     ],
                     [
                         "-left-64",
-                        "left: -16rem;",
-                        ""
+                        "left: -16rem;"
                     ],
                     [
                         "inset-72",
-                        "top: 18rem;\nright: 18rem;\nbottom: 18rem;\nleft: 18rem;",
-                        ""
+                        "top: 18rem;\nright: 18rem;\nbottom: 18rem;\nleft: 18rem;"
                     ],
                     [
                         "-inset-72",
-                        "top: -18rem;\nright: -18rem;\nbottom: -18rem;\nleft: -18rem;",
-                        ""
+                        "top: -18rem;\nright: -18rem;\nbottom: -18rem;\nleft: -18rem;"
                     ],
                     [
                         "inset-y-72",
-                        "top: 18rem;\nbottom: 18rem;",
-                        ""
+                        "top: 18rem;\nbottom: 18rem;"
                     ],
                     [
                         "-inset-y-72",
-                        "top: -18rem;\nbottom: -18rem;",
-                        ""
+                        "top: -18rem;\nbottom: -18rem;"
                     ],
                     [
                         "inset-x-72",
-                        "right: 18rem;\nleft: 18rem;",
-                        ""
+                        "right: 18rem;\nleft: 18rem;"
                     ],
                     [
                         "-inset-x-72",
-                        "right: -18rem;\nleft: -18rem;",
-                        ""
+                        "right: -18rem;\nleft: -18rem;"
                     ],
                     [
                         "top-72",
-                        "top: 18rem;",
-                        ""
+                        "top: 18rem;"
                     ],
                     [
                         "right-72",
-                        "right: 18rem;",
-                        ""
+                        "right: 18rem;"
                     ],
                     [
                         "bottom-72",
-                        "bottom: 18rem;",
-                        ""
+                        "bottom: 18rem;"
                     ],
                     [
                         "left-72",
-                        "left: 18rem;",
-                        ""
+                        "left: 18rem;"
                     ],
                     [
                         "-top-72",
-                        "top: -18rem;",
-                        ""
+                        "top: -18rem;"
                     ],
                     [
                         "-right-72",
-                        "right: -18rem;",
-                        ""
+                        "right: -18rem;"
                     ],
                     [
                         "-bottom-72",
-                        "bottom: -18rem;",
-                        ""
+                        "bottom: -18rem;"
                     ],
                     [
                         "-left-72",
-                        "left: -18rem;",
-                        ""
+                        "left: -18rem;"
                     ],
                     [
                         "inset-80",
-                        "top: 20;\nright: 20;\nbottom: 20;\nleft: 20;",
-                        ""
+                        "top: 20;\nright: 20;\nbottom: 20;\nleft: 20;"
                     ],
                     [
                         "-inset-80",
-                        "top: -20;\nright: -20;\nbottom: -20;\nleft: -20;",
-                        ""
+                        "top: -20;\nright: -20;\nbottom: -20;\nleft: -20;"
                     ],
                     [
                         "inset-y-80",
-                        "top: 20;\nbottom: 20;",
-                        ""
+                        "top: 20;\nbottom: 20;"
                     ],
                     [
                         "-inset-y-80",
-                        "top: -20;\nbottom: -20;",
-                        ""
+                        "top: -20;\nbottom: -20;"
                     ],
                     [
                         "inset-x-80",
-                        "right: 20;\nleft: 20;",
-                        ""
+                        "right: 20;\nleft: 20;"
                     ],
                     [
                         "-inset-x-80",
-                        "right: -20;\nleft: -20;",
-                        ""
+                        "right: -20;\nleft: -20;"
                     ],
                     [
                         "top-80",
-                        "top: 20;",
-                        ""
+                        "top: 20;"
                     ],
                     [
                         "right-80",
-                        "right: 20;",
-                        ""
+                        "right: 20;"
                     ],
                     [
                         "bottom-80",
-                        "bottom: 20;",
-                        ""
+                        "bottom: 20;"
                     ],
                     [
                         "left-80",
-                        "left: 20;",
-                        ""
+                        "left: 20;"
                     ],
                     [
                         "-top-80",
-                        "top: -20;",
-                        ""
+                        "top: -20;"
                     ],
                     [
                         "-right-80",
-                        "right: -20;",
-                        ""
+                        "right: -20;"
                     ],
                     [
                         "-bottom-80",
-                        "bottom: -20;",
-                        ""
+                        "bottom: -20;"
                     ],
                     [
                         "-left-80",
-                        "left: -20rem;",
-                        ""
+                        "left: -20rem;"
                     ],
                     [
                         "inset-96",
-                        "top: 24rem;\nright: 24rem;\nbottom: 24rem;\nleft: 24rem;",
-                        ""
+                        "top: 24rem;\nright: 24rem;\nbottom: 24rem;\nleft: 24rem;"
                     ],
                     [
                         "-inset-96",
-                        "top: -24rem;\nright: -24rem;\nbottom: -24rem;\nleft: -24rem;",
-                        ""
+                        "top: -24rem;\nright: -24rem;\nbottom: -24rem;\nleft: -24rem;"
                     ],
                     [
                         "inset-y-96",
-                        "top: 24rem;\nbottom: 24rem;",
-                        ""
+                        "top: 24rem;\nbottom: 24rem;"
                     ],
                     [
                         "-inset-y-96",
-                        "top: -24rem;\nbottom: -24rem;",
-                        ""
+                        "top: -24rem;\nbottom: -24rem;"
                     ],
                     [
                         "inset-x-96",
-                        "right: 24rem;\nleft: 24rem;",
-                        ""
+                        "right: 24rem;\nleft: 24rem;"
                     ],
                     [
                         "-inset-x-96",
-                        "right: -24rem;\nleft: -24rem;",
-                        ""
+                        "right: -24rem;\nleft: -24rem;"
                     ],
                     [
                         "top-96",
-                        "top: 24rem;",
-                        ""
+                        "top: 24rem;"
                     ],
                     [
                         "right-96",
-                        "right: 24rem;",
-                        ""
+                        "right: 24rem;"
                     ],
                     [
                         "bottom-96",
-                        "bottom: 24rem;",
-                        ""
+                        "bottom: 24rem;"
                     ],
                     [
                         "left-96",
-                        "left: 24rem;",
-                        ""
+                        "left: 24rem;"
                     ],
                     [
                         "-top-96",
-                        "top: -24rem;",
-                        ""
+                        "top: -24rem;"
                     ],
                     [
                         "-right-96",
-                        "right: -24rem;",
-                        ""
+                        "right: -24rem;"
                     ],
                     [
                         "-bottom-96",
-                        "bottom: -24rem;",
-                        ""
+                        "bottom: -24rem;"
                     ],
                     [
                         "-left-96",
-                        "left: -24rem;",
-                        ""
+                        "left: -24rem;"
                     ],
                     [
                         "inset-auto",
-                        "top: auto;\nright: auto;\nbottom: auto;\nleft: auto;",
-                        ""
+                        "top: auto;\nright: auto;\nbottom: auto;\nleft: auto;"
                     ],
                     [
                         "inset-y-auto",
-                        "top: auto;\nbottom: auto;",
-                        ""
+                        "top: auto;\nbottom: auto;"
                     ],
                     [
                         "inset-x-auto",
-                        "right: auto;\nleft: auto;",
-                        ""
+                        "right: auto;\nleft: auto;"
                     ],
                     [
                         "top-auto",
-                        "top: auto;",
-                        ""
+                        "top: auto;"
                     ],
                     [
                         "right-auto",
-                        "right: auto;",
-                        ""
+                        "right: auto;"
                     ],
                     [
                         "bottom-auto",
-                        "bottom: auto;",
-                        ""
+                        "bottom: auto;"
                     ],
                     [
                         "left-auto",
-                        "left: auto;",
-                        ""
+                        "left: auto;"
                     ],
                     [
                         "inset-1/2",
-                        "top: 50%;\nright: 50%;\nbottom: 50%;\nleft: 50%;",
-                        ""
+                        "top: 50%;\nright: 50%;\nbottom: 50%;\nleft: 50%;"
                     ],
                     [
                         "inset-2/3",
-                        "top: 66.666667%;\nright: 66.666667%;\nbottom: 66.666667%;\nleft: 66.666667%;",
-                        ""
+                        "top: 66.666667%;\nright: 66.666667%;\nbottom: 66.666667%;\nleft: 66.666667%;"
                     ],
                     [
                         "inset-1/4",
-                        "top: 25%;\nright: 25%;\nbottom: 25%;\nleft: 25%;",
-                        ""
+                        "top: 25%;\nright: 25%;\nbottom: 25%;\nleft: 25%;"
                     ],
                     [
                         "inset-3/4",
-                        "top: 75%;\nright: 75%;\nbottom: 75%;\nleft: 75%;",
-                        ""
+                        "top: 75%;\nright: 75%;\nbottom: 75%;\nleft: 75%;"
                     ],
                     [
                         "inset-full",
-                        "top: 100%;\nright: 100%;\nbottom: 100%;\nleft: 100%;",
-                        ""
+                        "top: 100%;\nright: 100%;\nbottom: 100%;\nleft: 100%;"
                     ],
                     [
                         "-inset-1/2",
-                        "top: -50%;\nright: -50%;\nbottom: -50%;\nleft: -50%;",
-                        ""
+                        "top: -50%;\nright: -50%;\nbottom: -50%;\nleft: -50%;"
                     ],
                     [
                         "-inset-2/3",
-                        "top: -66.666667%;\nright: -66.666667%;\nbottom: -66.666667%;\nleft: -66.666667%;",
-                        ""
+                        "top: -66.666667%;\nright: -66.666667%;\nbottom: -66.666667%;\nleft: -66.666667%;"
                     ],
                     [
                         "-inset-1/4",
-                        "top: -25%;\nright: -25%;\nbottom: -25%;\nleft: -25%;",
-                        ""
+                        "top: -25%;\nright: -25%;\nbottom: -25%;\nleft: -25%;"
                     ],
                     [
                         "-inset-3/4",
-                        "top: -75%;\nright: -75%;\nbottom: -75%;\nleft: -75%;",
-                        ""
+                        "top: -75%;\nright: -75%;\nbottom: -75%;\nleft: -75%;"
                     ],
                     [
                         "-inset-full",
-                        "top: -100%;\nright: -100%;\nbottom: -100%;\nleft: -100%;",
-                        ""
+                        "top: -100%;\nright: -100%;\nbottom: -100%;\nleft: -100%;"
                     ],
                     [
                         "inset-x-1/2",
-                        "right: 50%;\nleft: 50%;",
-                        ""
+                        "right: 50%;\nleft: 50%;"
                     ],
                     [
                         "inset-x-2/3",
-                        "right: 66.666667%;\nleft: 66.666667%;",
-                        ""
+                        "right: 66.666667%;\nleft: 66.666667%;"
                     ],
                     [
                         "inset-x-1/4",
-                        "right: 25%;\nleft: 25%;",
-                        ""
+                        "right: 25%;\nleft: 25%;"
                     ],
                     [
                         "inset-x-3/4",
-                        "right: 75%;\nleft: 75%;",
-                        ""
+                        "right: 75%;\nleft: 75%;"
                     ],
                     [
                         "inset-x-full",
-                        "right: 100%;\nleft: 100%;",
-                        ""
+                        "right: 100%;\nleft: 100%;"
                     ],
                     [
                         "-inset-x-1/2",
-                        "right: -50%;\nleft: -50%;",
-                        ""
+                        "right: -50%;\nleft: -50%;"
                     ],
                     [
                         "-inset-x-2/3",
-                        "right: -66.666667%;\nleft: -66.666667%;",
-                        ""
+                        "right: -66.666667%;\nleft: -66.666667%;"
                     ],
                     [
                         "-inset-x-1/4",
-                        "right: -25%;\nleft: -25%;",
-                        ""
+                        "right: -25%;\nleft: -25%;"
                     ],
                     [
                         "-inset-x-3/4",
-                        "right: -75%;\nleft: -75%;",
-                        ""
+                        "right: -75%;\nleft: -75%;"
                     ],
                     [
                         "-inset-x-full",
-                        "right: -100%;\nleft: -100%;",
-                        ""
+                        "right: -100%;\nleft: -100%;"
                     ],
                     [
                         "inset-y-1/2",
-                        "top: 50%;\nbottom: 50%;",
-                        ""
+                        "top: 50%;\nbottom: 50%;"
                     ],
                     [
                         "inset-y-2/3",
-                        "top: 66.666667%;\nbottom: 66.666667%;",
-                        ""
+                        "top: 66.666667%;\nbottom: 66.666667%;"
                     ],
                     [
                         "inset-y-1/4",
-                        "top: 25%;\nbottom: 25%;",
-                        ""
+                        "top: 25%;\nbottom: 25%;"
                     ],
                     [
                         "inset-y-3/4",
-                        "top: 75%;\nbottom: 75%;",
-                        ""
+                        "top: 75%;\nbottom: 75%;"
                     ],
                     [
                         "inset-y-full",
-                        "top: 100%;\nbottom: 100%;",
-                        ""
+                        "top: 100%;\nbottom: 100%;"
                     ],
                     [
                         "-inset-y-1/2",
-                        "top: -50%;\nbottom: -50%;",
-                        ""
+                        "top: -50%;\nbottom: -50%;"
                     ],
                     [
                         "-inset-y-2/3",
-                        "top: -66.666667%;\nbottom: -66.666667%;",
-                        ""
+                        "top: -66.666667%;\nbottom: -66.666667%;"
                     ],
                     [
                         "-inset-y-1/4",
-                        "top: -25%;\nbottom: -25%;",
-                        ""
+                        "top: -25%;\nbottom: -25%;"
                     ],
                     [
                         "-inset-y-3/4",
-                        "top: -75%;\nbottom: -75%;",
-                        ""
+                        "top: -75%;\nbottom: -75%;"
                     ],
                     [
                         "-inset-y-full",
-                        "top: -100%;\nbottom: -100%;",
-                        ""
+                        "top: -100%;\nbottom: -100%;"
                     ],
                     [
                         "top-1/2",
-                        "top: 50%;",
-                        ""
+                        "top: 50%;"
                     ],
                     [
                         "top-2/3",
-                        "top: 66.666667%;",
-                        ""
+                        "top: 66.666667%;"
                     ],
                     [
                         "top-1/4",
-                        "top: 25%;",
-                        ""
+                        "top: 25%;"
                     ],
                     [
                         "top-3/4",
-                        "top: 75%;",
-                        ""
+                        "top: 75%;"
                     ],
                     [
                         "top-full",
-                        "top: 100%;",
-                        ""
+                        "top: 100%;"
                     ],
                     [
                         "-top-1/2",
-                        "top: -50%;",
-                        ""
+                        "top: -50%;"
                     ],
                     [
                         "-top-2/3",
-                        "top: -66.666667%;",
-                        ""
+                        "top: -66.666667%;"
                     ],
                     [
                         "-top-1/4",
-                        "top: -25%;",
-                        ""
+                        "top: -25%;"
                     ],
                     [
                         "-top-3/4",
-                        "top: -75%;",
-                        ""
+                        "top: -75%;"
                     ],
                     [
                         "-top-full",
-                        "top: -100%;",
-                        ""
+                        "top: -100%;"
                     ],
                     [
                         "right-1/2",
-                        "right: 50%;",
-                        ""
+                        "right: 50%;"
                     ],
                     [
                         "right-2/3",
-                        "right: 66.666667%;",
-                        ""
+                        "right: 66.666667%;"
                     ],
                     [
                         "right-1/4",
-                        "right: 25%;",
-                        ""
+                        "right: 25%;"
                     ],
                     [
                         "right-3/4",
-                        "right: 75%;",
-                        ""
+                        "right: 75%;"
                     ],
                     [
                         "right-full",
-                        "right: 100%;",
-                        ""
+                        "right: 100%;"
                     ],
                     [
                         "-right-1/2",
-                        "right: -50%;",
-                        ""
+                        "right: -50%;"
                     ],
                     [
                         "-right-2/3",
-                        "right: -66.666667%;",
-                        ""
+                        "right: -66.666667%;"
                     ],
                     [
                         "-right-1/4",
-                        "right: -25%;",
-                        ""
+                        "right: -25%;"
                     ],
                     [
                         "-right-3/4",
-                        "right: -75%;",
-                        ""
+                        "right: -75%;"
                     ],
                     [
                         "-right-full",
-                        "right: -100%;",
-                        ""
+                        "right: -100%;"
                     ],
                     [
                         "bottom-1/2",
-                        "bottom: 50%;",
-                        ""
+                        "bottom: 50%;"
                     ],
                     [
                         "bottom-2/3",
-                        "bottom: 66.666667%;",
-                        ""
+                        "bottom: 66.666667%;"
                     ],
                     [
                         "bottom-1/4",
-                        "bottom: 25%;",
-                        ""
+                        "bottom: 25%;"
                     ],
                     [
                         "bottom-3/4",
-                        "bottom: 75%;",
-                        ""
+                        "bottom: 75%;"
                     ],
                     [
                         "bottom-full",
-                        "bottom: 100%;",
-                        ""
+                        "bottom: 100%;"
                     ],
                     [
                         "-bottom-1/2",
-                        "bottom: -50%;",
-                        ""
+                        "bottom: -50%;"
                     ],
                     [
                         "-bottom-2/3",
-                        "bottom: -66.666667%;",
-                        ""
+                        "bottom: -66.666667%;"
                     ],
                     [
                         "-bottom-1/4",
-                        "bottom: -25%;",
-                        ""
+                        "bottom: -25%;"
                     ],
                     [
                         "-bottom-3/4",
-                        "bottom: -75%;",
-                        ""
+                        "bottom: -75%;"
                     ],
                     [
                         "-bottom-full",
-                        "bottom: -100%;",
-                        ""
+                        "bottom: -100%;"
                     ],
                     [
                         "left-1/2",
-                        "left: 50%;",
-                        ""
+                        "left: 50%;"
                     ],
                     [
                         "left-2/3",
-                        "left: 66.666667%;",
-                        ""
+                        "left: 66.666667%;"
                     ],
                     [
                         "left-1/4",
-                        "left: 25%;",
-                        ""
+                        "left: 25%;"
                     ],
                     [
                         "left-3/4",
-                        "left: 75%;",
-                        ""
+                        "left: 75%;"
                     ],
                     [
                         "left-full",
-                        "left: 100%;",
-                        ""
+                        "left: 100%;"
                     ],
                     [
                         "-left-1/2",
-                        "left: -50%;",
-                        ""
+                        "left: -50%;"
                     ],
                     [
                         "-left-2/3",
-                        "left: -66.666667%;",
-                        ""
+                        "left: -66.666667%;"
                     ],
                     [
                         "-left-1/4",
-                        "left: -25%;",
-                        ""
+                        "left: -25%;"
                     ],
                     [
                         "-left-3/4",
-                        "left: -75%;",
-                        ""
+                        "left: -75%;"
                     ],
                     [
                         "-left-full",
-                        "left: -100%;",
-                        ""
+                        "left: -100%;"
                     ]
                 ]
             },
@@ -3561,13 +2878,11 @@
                 "table": [
                     [
                         "visible",
-                        "visibility: visible;",
-                        ""
+                        "visibility: visible;"
                     ],
                     [
                         "invisible",
-                        "visibility: hidden;",
-                        ""
+                        "visibility: hidden;"
                     ]
                 ]
             },
@@ -3578,38 +2893,31 @@
                 "table": [
                     [
                         "z-0",
-                        "z-index: 0;",
-                        ""
+                        "z-index: 0;"
                     ],
                     [
                         "z-10",
-                        "z-index: 10;",
-                        ""
+                        "z-index: 10;"
                     ],
                     [
                         "z-20",
-                        "z-index: 20;",
-                        ""
+                        "z-index: 20;"
                     ],
                     [
                         "z-30",
-                        "z-index: 30;",
-                        ""
+                        "z-index: 30;"
                     ],
                     [
                         "z-40",
-                        "z-index: 40;",
-                        ""
+                        "z-index: 40;"
                     ],
                     [
                         "z-50",
-                        "z-index: 50;",
-                        ""
+                        "z-index: 50;"
                     ],
                     [
                         "z-auto",
-                        "z-index: auto;",
-                        ""
+                        "z-index: auto;"
                     ]
                 ]
             }
@@ -3625,8 +2933,7 @@
                 "table": [
                     [
                         "p-0",
-                        "padding: 0;",
-                        ""
+                        "padding: 0;"
                     ],
                     [
                         "p-0.5",
@@ -3780,18 +3087,15 @@
                     ],
                     [
                         "p-px",
-                        "padding: 1px;",
-                        ""
+                        "padding: 1px;"
                     ],
                     [
                         "py-0",
-                        "padding-top: 0;\npadding-bottom: 0;",
-                        ""
+                        "padding-top: 0;\npadding-bottom: 0;"
                     ],
                     [
                         "px-0",
-                        "padding-left: 0;\npadding-right: 0;",
-                        ""
+                        "padding-left: 0;\npadding-right: 0;"
                     ],
                     [
                         "py-0.5",
@@ -4125,33 +3429,27 @@
                     ],
                     [
                         "py-px",
-                        "padding-top: 1px;\npadding-bottom: 1px;",
-                        ""
+                        "padding-top: 1px;\npadding-bottom: 1px;"
                     ],
                     [
                         "px-px",
-                        "padding-left: 1px;\npadding-right: 1px;",
-                        ""
+                        "padding-left: 1px;\npadding-right: 1px;"
                     ],
                     [
                         "pt-0",
-                        "padding-top: 0;",
-                        ""
+                        "padding-top: 0;"
                     ],
                     [
                         "pr-0",
-                        "padding-right: 0;",
-                        ""
+                        "padding-right: 0;"
                     ],
                     [
                         "pb-0",
-                        "padding-bottom: 0;",
-                        ""
+                        "padding-bottom: 0;"
                     ],
                     [
                         "pl-0",
-                        "padding-left: 0;",
-                        ""
+                        "padding-left: 0;"
                     ],
                     [
                         "pt-0.5",
@@ -4815,23 +4113,19 @@
                     ],
                     [
                         "pt-px",
-                        "padding-top: 1px;",
-                        ""
+                        "padding-top: 1px;"
                     ],
                     [
                         "pr-px",
-                        "padding-right: 1px;",
-                        ""
+                        "padding-right: 1px;"
                     ],
                     [
                         "pb-px",
-                        "padding-bottom: 1px;",
-                        ""
+                        "padding-bottom: 1px;"
                     ],
                     [
                         "pl-px",
-                        "padding-left: 1px;",
-                        ""
+                        "padding-left: 1px;"
                     ]
                 ]
             },
@@ -4842,8 +4136,7 @@
                 "table": [
                     [
                         "m-0",
-                        "margin: 0;",
-                        ""
+                        "margin: 0;"
                     ],
                     [
                         "m-0.5",
@@ -4997,18 +4290,15 @@
                     ],
                     [
                         "m-px",
-                        "margin: 1px;",
-                        ""
+                        "margin: 1px;"
                     ],
                     [
                         "my-0",
-                        "margin-top: 0;\nmargin-bottom: 0;",
-                        ""
+                        "margin-top: 0;\nmargin-bottom: 0;"
                     ],
                     [
                         "mx-0",
-                        "margin-left: 0;\nmargin-right: 0;",
-                        ""
+                        "margin-left: 0;\nmargin-right: 0;"
                     ],
                     [
                         "my-0.5",
@@ -5342,33 +4632,27 @@
                     ],
                     [
                         "my-px",
-                        "margin-top: 1px;\nmargin-bottom: 1px;",
-                        ""
+                        "margin-top: 1px;\nmargin-bottom: 1px;"
                     ],
                     [
                         "mx-px",
-                        "margin-left: 1px;\nmargin-right: 1px;",
-                        ""
+                        "margin-left: 1px;\nmargin-right: 1px;"
                     ],
                     [
                         "mt-0",
-                        "margin-top: 0;",
-                        ""
+                        "margin-top: 0;"
                     ],
                     [
                         "mr-0",
-                        "margin-right: 0;",
-                        ""
+                        "margin-right: 0;"
                     ],
                     [
                         "mb-0",
-                        "margin-bottom: 0;",
-                        ""
+                        "margin-bottom: 0;"
                     ],
                     [
                         "ml-0",
-                        "margin-left: 0;",
-                        ""
+                        "margin-left: 0;"
                     ],
                     [
                         "mt-0.5",
@@ -6032,28 +5316,23 @@
                     ],
                     [
                         "mt-px",
-                        "margin-top: 1px;",
-                        ""
+                        "margin-top: 1px;"
                     ],
                     [
                         "mr-px",
-                        "margin-right: 1px;",
-                        ""
+                        "margin-right: 1px;"
                     ],
                     [
                         "mb-px",
-                        "margin-bottom: 1px;",
-                        ""
+                        "margin-bottom: 1px;"
                     ],
                     [
                         "ml-px",
-                        "margin-left: 1px;",
-                        ""
+                        "margin-left: 1px;"
                     ],
                     [
                         "-m-0",
-                        "margin: 0;",
-                        ""
+                        "margin: 0;"
                     ],
                     [
                         "-m-0.5",
@@ -6207,18 +5486,15 @@
                     ],
                     [
                         "-m-px",
-                        "margin: -1px;",
-                        ""
+                        "margin: -1px;"
                     ],
                     [
                         "-my-0",
-                        "margin-top: 0;\nmargin-bottom: 0;",
-                        ""
+                        "margin-top: 0;\nmargin-bottom: 0;"
                     ],
                     [
                         "-mx-0",
-                        "margin-left: 0;\nmargin-right: 0;",
-                        ""
+                        "margin-left: 0;\nmargin-right: 0;"
                     ],
                     [
                         "-my-0.5",
@@ -6552,33 +5828,27 @@
                     ],
                     [
                         "-my-px",
-                        "margin-top: -1px;\nmargin-bottom: -1px;",
-                        ""
+                        "margin-top: -1px;\nmargin-bottom: -1px;"
                     ],
                     [
                         "-mx-px",
-                        "margin-left: -1px;\nmargin-right: -1px;",
-                        ""
+                        "margin-left: -1px;\nmargin-right: -1px;"
                     ],
                     [
                         "-mt-0",
-                        "margin-top: 0;",
-                        ""
+                        "margin-top: 0;"
                     ],
                     [
                         "-mr-0",
-                        "margin-right: 0;",
-                        ""
+                        "margin-right: 0;"
                     ],
                     [
                         "-mb-0",
-                        "margin-bottom: 0;",
-                        ""
+                        "margin-bottom: 0;"
                     ],
                     [
                         "-ml-0",
-                        "margin-left: 0;",
-                        ""
+                        "margin-left: 0;"
                     ],
                     [
                         "-mt-0.5",
@@ -7242,23 +6512,19 @@
                     ],
                     [
                         "-mt-px",
-                        "margin-top: -1px;",
-                        ""
+                        "margin-top: -1px;"
                     ],
                     [
                         "-mr-px",
-                        "margin-right: -1px;",
-                        ""
+                        "margin-right: -1px;"
                     ],
                     [
                         "-mb-px",
-                        "margin-bottom: -1px;",
-                        ""
+                        "margin-bottom: -1px;"
                     ],
                     [
                         "-ml-px",
-                        "margin-left: -1px;",
-                        ""
+                        "margin-left: -1px;"
                     ]
                 ]
             },
@@ -7269,713 +6535,571 @@
                 "table": [
                     [
                         "space-x-0",
-                        "margin-left: 0;",
-                        ""
+                        "margin-left: 0;"
                     ],
                     [
                         "space-x-0.5",
-                        "margin-left: 0.125rem;",
-                        ""
+                        "margin-left: 0.125rem;"
                     ],
                     [
                         "space-x-1",
-                        "margin-left: 0.25rem;",
-                        ""
+                        "margin-left: 0.25rem;"
                     ],
                     [
                         "space-x-1.5",
-                        "margin-left: 0.375rem;",
-                        ""
+                        "margin-left: 0.375rem;"
                     ],
                     [
                         "space-x-2",
-                        "margin-left: 0.5rem;",
-                        ""
+                        "margin-left: 0.5rem;"
                     ],
                     [
                         "space-x-2.5",
-                        "margin-left: 0.625rem;",
-                        ""
+                        "margin-left: 0.625rem;"
                     ],
                     [
                         "space-x-3",
-                        "margin-left: 0.75rem;",
-                        ""
+                        "margin-left: 0.75rem;"
                     ],
                     [
                         "space-x-3",
-                        "margin-left: 0.875rem;",
-                        ""
+                        "margin-left: 0.875rem;"
                     ],
                     [
                         "space-x-4",
-                        "margin-left: 1rem;",
-                        ""
+                        "margin-left: 1rem;"
                     ],
                     [
                         "space-x-5",
-                        "margin-left: 1.25rem;",
-                        ""
+                        "margin-left: 1.25rem;"
                     ],
                     [
                         "space-x-6",
-                        "margin-left: 1.5rem;",
-                        ""
+                        "margin-left: 1.5rem;"
                     ],
                     [
                         "space-x-7",
-                        "margin-left: 1.75rem;",
-                        ""
+                        "margin-left: 1.75rem;"
                     ],
                     [
                         "space-x-8",
-                        "margin-left: 2rem;",
-                        ""
+                        "margin-left: 2rem;"
                     ],
                     [
                         "space-x-9",
-                        "margin-left: 2.25rem;",
-                        ""
+                        "margin-left: 2.25rem;"
                     ],
                     [
                         "space-x-10",
-                        "margin-left: 2.5rem;",
-                        ""
+                        "margin-left: 2.5rem;"
                     ],
                     [
                         "space-x-11",
-                        "margin-left: 2.75rem;",
-                        ""
+                        "margin-left: 2.75rem;"
                     ],
                     [
                         "space-x-12",
-                        "margin-left: 3rem;",
-                        ""
+                        "margin-left: 3rem;"
                     ],
                     [
                         "space-x-14",
-                        "margin-left: 3.5rem;",
-                        ""
+                        "margin-left: 3.5rem;"
                     ],
                     [
                         "space-x-16",
-                        "margin-left: 4rem;",
-                        ""
+                        "margin-left: 4rem;"
                     ],
                     [
                         "space-x-20",
-                        "margin-left: 5rem;",
-                        ""
+                        "margin-left: 5rem;"
                     ],
                     [
                         "space-x-24",
-                        "margin-left: 6rem;",
-                        ""
+                        "margin-left: 6rem;"
                     ],
                     [
                         "space-x-28",
-                        "margin-left: 7rem;",
-                        ""
+                        "margin-left: 7rem;"
                     ],
                     [
                         "space-x-32",
-                        "margin-left: 8rem;",
-                        ""
+                        "margin-left: 8rem;"
                     ],
                     [
                         "space-x-36",
-                        "margin-left: 9rem;",
-                        ""
+                        "margin-left: 9rem;"
                     ],
                     [
                         "space-x-40",
-                        "margin-left: 10rem;",
-                        ""
+                        "margin-left: 10rem;"
                     ],
                     [
                         "space-x-44",
-                        "margin-left: 11rem;",
-                        ""
+                        "margin-left: 11rem;"
                     ],
                     [
                         "space-x-48",
-                        "margin-left: 12rem;",
-                        ""
+                        "margin-left: 12rem;"
                     ],
                     [
                         "space-x-52",
-                        "margin-left: 13rem;",
-                        ""
+                        "margin-left: 13rem;"
                     ],
                     [
                         "space-x-56",
-                        "margin-left: 14rem;",
-                        ""
+                        "margin-left: 14rem;"
                     ],
                     [
                         "space-x-60",
-                        "margin-left: 15rem;",
-                        ""
+                        "margin-left: 15rem;"
                     ],
                     [
                         "space-x-64",
-                        "margin-left: 16rem;",
-                        ""
+                        "margin-left: 16rem;"
                     ],
                     [
                         "space-x-72",
-                        "margin-left: 18rem;",
-                        ""
+                        "margin-left: 18rem;"
                     ],
                     [
                         "space-x-80",
-                        "margin-left: 20rem;",
-                        ""
+                        "margin-left: 20rem;"
                     ],
                     [
                         "space-x-96",
-                        "margin-left: 24rem;",
-                        ""
+                        "margin-left: 24rem;"
                     ],
                     [
                         "space-x-px",
-                        "margin-left: 1px;",
-                        ""
+                        "margin-left: 1px;"
                     ],
                     [
                         "-space-x-0",
-                        "margin-left: 0;",
-                        ""
+                        "margin-left: 0;"
                     ],
                     [
                         "-space-x-0.5",
-                        "margin-left: -0.125rem;",
-                        ""
+                        "margin-left: -0.125rem;"
                     ],
                     [
                         "-space-x-1",
-                        "margin-left: -0.25rem;",
-                        ""
+                        "margin-left: -0.25rem;"
                     ],
                     [
                         "-space-x-1.5",
-                        "margin-left: -0.375rem;",
-                        ""
+                        "margin-left: -0.375rem;"
                     ],
                     [
                         "-space-x-2",
-                        "margin-left: -0.5rem;",
-                        ""
+                        "margin-left: -0.5rem;"
                     ],
                     [
                         "-space-x-2.5",
-                        "margin-left: -0.625rem;",
-                        ""
+                        "margin-left: -0.625rem;"
                     ],
                     [
                         "-space-x-3",
-                        "margin-left: -0.75rem;",
-                        ""
+                        "margin-left: -0.75rem;"
                     ],
                     [
                         "-space-x-3",
-                        "margin-left: -0.875rem;",
-                        ""
+                        "margin-left: -0.875rem;"
                     ],
                     [
                         "-space-x-4",
-                        "margin-left: -1rem;",
-                        ""
+                        "margin-left: -1rem;"
                     ],
                     [
                         "-space-x-5",
-                        "margin-left: -1.25rem;",
-                        ""
+                        "margin-left: -1.25rem;"
                     ],
                     [
                         "-space-x-6",
-                        "margin-left: -1.5rem;",
-                        ""
+                        "margin-left: -1.5rem;"
                     ],
                     [
                         "-space-x-7",
-                        "margin-left: -1.75rem;",
-                        ""
+                        "margin-left: -1.75rem;"
                     ],
                     [
                         "-space-x-8",
-                        "margin-left: -2rem;",
-                        ""
+                        "margin-left: -2rem;"
                     ],
                     [
                         "-space-x-9",
-                        "margin-left: -2.25rem;",
-                        ""
+                        "margin-left: -2.25rem;"
                     ],
                     [
                         "-space-x-10",
-                        "margin-left: -2.5rem;",
-                        ""
+                        "margin-left: -2.5rem;"
                     ],
                     [
                         "-space-x-11",
-                        "margin-left: -2.75rem;",
-                        ""
+                        "margin-left: -2.75rem;"
                     ],
                     [
                         "-space-x-12",
-                        "margin-left: -3rem;",
-                        ""
+                        "margin-left: -3rem;"
                     ],
                     [
                         "-space-x-14",
-                        "margin-left: -3.5rem;",
-                        ""
+                        "margin-left: -3.5rem;"
                     ],
                     [
                         "-space-x-16",
-                        "margin-left: -4rem;",
-                        ""
+                        "margin-left: -4rem;"
                     ],
                     [
                         "-space-x-20",
-                        "margin-left: -5rem;",
-                        ""
+                        "margin-left: -5rem;"
                     ],
                     [
                         "-space-x-24",
-                        "margin-left: -6rem;",
-                        ""
+                        "margin-left: -6rem;"
                     ],
                     [
                         "-space-x-28",
-                        "margin-left: -7rem;",
-                        ""
+                        "margin-left: -7rem;"
                     ],
                     [
                         "-space-x-32",
-                        "margin-left: -8rem;",
-                        ""
+                        "margin-left: -8rem;"
                     ],
                     [
                         "-space-x-36",
-                        "margin-left: -9rem;",
-                        ""
+                        "margin-left: -9rem;"
                     ],
                     [
                         "-space-x-40",
-                        "margin-left: -10rem;",
-                        ""
+                        "margin-left: -10rem;"
                     ],
                     [
                         "-space-x-44",
-                        "margin-left: -11rem;",
-                        ""
+                        "margin-left: -11rem;"
                     ],
                     [
                         "-space-x-48",
-                        "margin-left: -12rem;",
-                        ""
+                        "margin-left: -12rem;"
                     ],
                     [
                         "-space-x-52",
-                        "margin-left: -13rem;",
-                        ""
+                        "margin-left: -13rem;"
                     ],
                     [
                         "-space-x-56",
-                        "margin-left: -14rem;",
-                        ""
+                        "margin-left: -14rem;"
                     ],
                     [
                         "-space-x-60",
-                        "margin-left: -15rem;",
-                        ""
+                        "margin-left: -15rem;"
                     ],
                     [
                         "-space-x-64",
-                        "margin-left: -16rem;",
-                        ""
+                        "margin-left: -16rem;"
                     ],
                     [
                         "-space-x-72",
-                        "margin-left: -18rem;",
-                        ""
+                        "margin-left: -18rem;"
                     ],
                     [
                         "-space-x-80",
-                        "margin-left: -20rem;",
-                        ""
+                        "margin-left: -20rem;"
                     ],
                     [
                         "-space-x-96",
-                        "margin-left: -24rem;",
-                        ""
+                        "margin-left: -24rem;"
                     ],
                     [
                         "-space-x-px",
-                        "margin-left: -1px;",
-                        ""
+                        "margin-left: -1px;"
                     ],
                     [
                         "space-y-0",
-                        "margin-top: 0;",
-                        ""
+                        "margin-top: 0;"
                     ],
                     [
                         "space-y-0.5",
-                        "margin-top: 0.125rem;",
-                        ""
+                        "margin-top: 0.125rem;"
                     ],
                     [
                         "space-y-1",
-                        "margin-top: 0.25rem;",
-                        ""
+                        "margin-top: 0.25rem;"
                     ],
                     [
                         "space-y-1.5",
-                        "margin-top: 0.375rem;",
-                        ""
+                        "margin-top: 0.375rem;"
                     ],
                     [
                         "space-y-2",
-                        "margin-top: 0.5rem;",
-                        ""
+                        "margin-top: 0.5rem;"
                     ],
                     [
                         "space-y-2.5",
-                        "margin-top: 0.625rem;",
-                        ""
+                        "margin-top: 0.625rem;"
                     ],
                     [
                         "space-y-3",
-                        "margin-top: 0.75rem;",
-                        ""
+                        "margin-top: 0.75rem;"
                     ],
                     [
                         "space-y-3",
-                        "margin-top: 0.875rem;",
-                        ""
+                        "margin-top: 0.875rem;"
                     ],
                     [
                         "space-y-4",
-                        "margin-top: 1rem;",
-                        ""
+                        "margin-top: 1rem;"
                     ],
                     [
                         "space-y-5",
-                        "margin-top: 1.25rem;",
-                        ""
+                        "margin-top: 1.25rem;"
                     ],
                     [
                         "space-y-6",
-                        "margin-top: 1.5rem;",
-                        ""
+                        "margin-top: 1.5rem;"
                     ],
                     [
                         "space-y-7",
-                        "margin-top: 1.75rem;",
-                        ""
+                        "margin-top: 1.75rem;"
                     ],
                     [
                         "space-y-8",
-                        "margin-top: 2rem;",
-                        ""
+                        "margin-top: 2rem;"
                     ],
                     [
                         "space-y-9",
-                        "margin-top: 2.25rem;",
-                        ""
+                        "margin-top: 2.25rem;"
                     ],
                     [
                         "space-y-10",
-                        "margin-top: 2.5rem;",
-                        ""
+                        "margin-top: 2.5rem;"
                     ],
                     [
                         "space-y-11",
-                        "margin-top: 2.75rem;",
-                        ""
+                        "margin-top: 2.75rem;"
                     ],
                     [
                         "space-y-12",
-                        "margin-top: 3rem;",
-                        ""
+                        "margin-top: 3rem;"
                     ],
                     [
                         "space-y-14",
-                        "margin-top: 3.5rem;",
-                        ""
+                        "margin-top: 3.5rem;"
                     ],
                     [
                         "space-y-16",
-                        "margin-top: 4rem;",
-                        ""
+                        "margin-top: 4rem;"
                     ],
                     [
                         "space-y-20",
-                        "margin-top: 5rem;",
-                        ""
+                        "margin-top: 5rem;"
                     ],
                     [
                         "space-y-24",
-                        "margin-top: 6rem;",
-                        ""
+                        "margin-top: 6rem;"
                     ],
                     [
                         "space-y-28",
-                        "margin-top: 7rem;",
-                        ""
+                        "margin-top: 7rem;"
                     ],
                     [
                         "space-y-32",
-                        "margin-top: 8rem;",
-                        ""
+                        "margin-top: 8rem;"
                     ],
                     [
                         "space-y-36",
-                        "margin-top: 9rem;",
-                        ""
+                        "margin-top: 9rem;"
                     ],
                     [
                         "space-y-40",
-                        "margin-top: 10rem;",
-                        ""
+                        "margin-top: 10rem;"
                     ],
                     [
                         "space-y-44",
-                        "margin-top: 11rem;",
-                        ""
+                        "margin-top: 11rem;"
                     ],
                     [
                         "space-y-48",
-                        "margin-top: 12rem;",
-                        ""
+                        "margin-top: 12rem;"
                     ],
                     [
                         "space-y-52",
-                        "margin-top: 13rem;",
-                        ""
+                        "margin-top: 13rem;"
                     ],
                     [
                         "space-y-56",
-                        "margin-top: 14rem;",
-                        ""
+                        "margin-top: 14rem;"
                     ],
                     [
                         "space-y-60",
-                        "margin-top: 15rem;",
-                        ""
+                        "margin-top: 15rem;"
                     ],
                     [
                         "space-y-64",
-                        "margin-top: 16rem;",
-                        ""
+                        "margin-top: 16rem;"
                     ],
                     [
                         "space-y-72",
-                        "margin-top: 18rem;",
-                        ""
+                        "margin-top: 18rem;"
                     ],
                     [
                         "space-y-80",
-                        "margin-top: 20rem;",
-                        ""
+                        "margin-top: 20rem;"
                     ],
                     [
                         "space-y-96",
-                        "margin-top: 24rem;",
-                        ""
+                        "margin-top: 24rem;"
                     ],
                     [
                         "space-y-px",
-                        "margin-top: 1px;",
-                        ""
+                        "margin-top: 1px;"
                     ],
                     [
                         "-space-y-0",
-                        "margin-top: 0;",
-                        ""
+                        "margin-top: 0;"
                     ],
                     [
                         "-space-y-0.5",
-                        "margin-top: -0.125rem;",
-                        ""
+                        "margin-top: -0.125rem;"
                     ],
                     [
                         "-space-y-1",
-                        "margin-top: -0.25rem;",
-                        ""
+                        "margin-top: -0.25rem;"
                     ],
                     [
                         "-space-y-1.5",
-                        "margin-top: -0.375rem;",
-                        ""
+                        "margin-top: -0.375rem;"
                     ],
                     [
                         "-space-y-2",
-                        "margin-top: -0.5rem;",
-                        ""
+                        "margin-top: -0.5rem;"
                     ],
                     [
                         "-space-y-2.5",
-                        "margin-top: -0.625rem;",
-                        ""
+                        "margin-top: -0.625rem;"
                     ],
                     [
                         "-space-y-3",
-                        "margin-top: -0.75rem;",
-                        ""
+                        "margin-top: -0.75rem;"
                     ],
                     [
                         "-space-y-3",
-                        "margin-top: -0.875rem;",
-                        ""
+                        "margin-top: -0.875rem;"
                     ],
                     [
                         "-space-y-4",
-                        "margin-top: -1rem;",
-                        ""
+                        "margin-top: -1rem;"
                     ],
                     [
                         "-space-y-5",
-                        "margin-top: -1.25rem;",
-                        ""
+                        "margin-top: -1.25rem;"
                     ],
                     [
                         "-space-y-6",
-                        "margin-top: -1.5rem;",
-                        ""
+                        "margin-top: -1.5rem;"
                     ],
                     [
                         "-space-y-7",
-                        "margin-top: -1.75rem;",
-                        ""
+                        "margin-top: -1.75rem;"
                     ],
                     [
                         "-space-y-8",
-                        "margin-top: -2rem;",
-                        ""
+                        "margin-top: -2rem;"
                     ],
                     [
                         "-space-y-9",
-                        "margin-top: -2.25rem;",
-                        ""
+                        "margin-top: -2.25rem;"
                     ],
                     [
                         "-space-y-10",
-                        "margin-top: -2.5rem;",
-                        ""
+                        "margin-top: -2.5rem;"
                     ],
                     [
                         "-space-y-11",
-                        "margin-top: -2.75rem;",
-                        ""
+                        "margin-top: -2.75rem;"
                     ],
                     [
                         "-space-y-12",
-                        "margin-top: -3rem;",
-                        ""
+                        "margin-top: -3rem;"
                     ],
                     [
                         "-space-y-14",
-                        "margin-top: -3.5rem;",
-                        ""
+                        "margin-top: -3.5rem;"
                     ],
                     [
                         "-space-y-16",
-                        "margin-top: -4rem;",
-                        ""
+                        "margin-top: -4rem;"
                     ],
                     [
                         "-space-y-20",
-                        "margin-top: -5rem;",
-                        ""
+                        "margin-top: -5rem;"
                     ],
                     [
                         "-space-y-24",
-                        "margin-top: -6rem;",
-                        ""
+                        "margin-top: -6rem;"
                     ],
                     [
                         "-space-y-28",
-                        "margin-top: -7rem;",
-                        ""
+                        "margin-top: -7rem;"
                     ],
                     [
                         "-space-y-32",
-                        "margin-top: -8rem;",
-                        ""
+                        "margin-top: -8rem;"
                     ],
                     [
                         "-space-y-36",
-                        "margin-top: -9rem;",
-                        ""
+                        "margin-top: -9rem;"
                     ],
                     [
                         "-space-y-40",
-                        "margin-top: -10rem;",
-                        ""
+                        "margin-top: -10rem;"
                     ],
                     [
                         "-space-y-44",
-                        "margin-top: -11rem;",
-                        ""
+                        "margin-top: -11rem;"
                     ],
                     [
                         "-space-y-48",
-                        "margin-top: -12rem;",
-                        ""
+                        "margin-top: -12rem;"
                     ],
                     [
                         "-space-y-52",
-                        "margin-top: -13rem;",
-                        ""
+                        "margin-top: -13rem;"
                     ],
                     [
                         "-space-y-56",
-                        "margin-top: -14rem;",
-                        ""
+                        "margin-top: -14rem;"
                     ],
                     [
                         "-space-y-60",
-                        "margin-top: -15rem;",
-                        ""
+                        "margin-top: -15rem;"
                     ],
                     [
                         "-space-y-64",
-                        "margin-top: -16rem;",
-                        ""
+                        "margin-top: -16rem;"
                     ],
                     [
                         "-space-y-72",
-                        "margin-top: -18rem;",
-                        ""
+                        "margin-top: -18rem;"
                     ],
                     [
                         "-space-y-80",
-                        "margin-top: -20rem;",
-                        ""
+                        "margin-top: -20rem;"
                     ],
                     [
                         "-space-y-96",
-                        "margin-top: -24rem;",
-                        ""
+                        "margin-top: -24rem;"
                     ],
                     [
                         "-space-y-px",
-                        "margin-top: -1px;",
-                        ""
+                        "margin-top: -1px;"
                     ],
                     [
                         "space-x-reverse",
-                        "--space-x-reverse: 1",
-                        ""
+                        "--space-x-reverse: 1"
                     ],
                     [
                         "space-y-reverse",
-                        "--space-y-reverse: 1",
-                        ""
+                        "--space-y-reverse: 1"
                     ]
                 ]
             }
@@ -7991,8 +7115,7 @@
                 "table": [
                     [
                         "basis-0",
-                        "flex-basis: 0px;",
-                        ""
+                        "flex-basis: 0px;"
                     ],
                     [
                         "basis-0.5",
@@ -8161,148 +7284,119 @@
                     ],
                     [
                         "basis-auto",
-                        "flex-basis: auto;",
-                        ""
+                        "flex-basis: auto;"
                     ],
                     [
                         "basis-px",
-                        "flex-basis: 1px;",
-                        ""
+                        "flex-basis: 1px;"
                     ],
                     [
                         "basis-1/2",
-                        "flex-basis: 50%;",
-                        ""
+                        "flex-basis: 50%;"
                     ],
                     [
                         "basis-1/3",
-                        "flex-basis: 33.333333%;",
-                        ""
+                        "flex-basis: 33.333333%;"
                     ],
                     [
                         "basis-2/3",
-                        "flex-basis: 66.666667%;",
-                        ""
+                        "flex-basis: 66.666667%;"
                     ],
                     [
                         "basis-1/4",
-                        "flex-basis: 25%;",
-                        ""
+                        "flex-basis: 25%;"
                     ],
                     [
                         "basis-2/4",
-                        "flex-basis: 50%;",
-                        ""
+                        "flex-basis: 50%;"
                     ],
                     [
                         "basis-3/4",
-                        "flex-basis: 75%;",
-                        ""
+                        "flex-basis: 75%;"
                     ],
                     [
                         "basis-1/5",
-                        "flex-basis: 20%;",
-                        ""
+                        "flex-basis: 20%;"
                     ],
                     [
                         "basis-2/5",
-                        "flex-basis: 40%;",
-                        ""
+                        "flex-basis: 40%;"
                     ],
                     [
                         "basis-3/5",
-                        "flex-basis: 60%;",
-                        ""
+                        "flex-basis: 60%;"
                     ],
                     [
                         "basis-4/5",
-                        "flex-basis: 80%;",
-                        ""
+                        "flex-basis: 80%;"
                     ],
                     [
                         "basis-1/6",
-                        "flex-basis: 16.666667%;",
-                        ""
+                        "flex-basis: 16.666667%;"
                     ],
                     [
                         "basis-2/6",
-                        "flex-basis: 33.333333%;",
-                        ""
+                        "flex-basis: 33.333333%;"
                     ],
                     [
                         "basis-3/6",
-                        "flex-basis: 50%;",
-                        ""
+                        "flex-basis: 50%;"
                     ],
                     [
                         "basis-4/6",
-                        "flex-basis: 66.666667%;",
-                        ""
+                        "flex-basis: 66.666667%;"
                     ],
                     [
                         "basis-5/6",
-                        "flex-basis: 83.333333%;",
-                        ""
+                        "flex-basis: 83.333333%;"
                     ],
                     [
                         "basis-1/12",
-                        "flex-basis: 8.333333%;",
-                        ""
+                        "flex-basis: 8.333333%;"
                     ],
                     [
                         "basis-2/12",
-                        "flex-basis: 16.666667%;",
-                        ""
+                        "flex-basis: 16.666667%;"
                     ],
                     [
                         "basis-3/12",
-                        "flex-basis: 25%;",
-                        ""
+                        "flex-basis: 25%;"
                     ],
                     [
                         "basis-4/12",
-                        "flex-basis: 33.333333%;",
-                        ""
+                        "flex-basis: 33.333333%;"
                     ],
                     [
                         "basis-5/12",
-                        "flex-basis: 41.666667%;",
-                        ""
+                        "flex-basis: 41.666667%;"
                     ],
                     [
                         "basis-6/12",
-                        "flex-basis: 50%;",
-                        ""
+                        "flex-basis: 50%;"
                     ],
                     [
                         "basis-7/12",
-                        "flex-basis: 58.333333%;",
-                        ""
+                        "flex-basis: 58.333333%;"
                     ],
                     [
                         "basis-8/12",
-                        "flex-basis: 66.666667%;",
-                        ""
+                        "flex-basis: 66.666667%;"
                     ],
                     [
                         "basis-9/12",
-                        "flex-basis: 75%;",
-                        ""
+                        "flex-basis: 75%;"
                     ],
                     [
                         "basis-10/12",
-                        "flex-basis: 83.333333%;",
-                        ""
+                        "flex-basis: 83.333333%;"
                     ],
                     [
                         "basis-11/12",
-                        "flex-basis: 91.666667%;",
-                        ""
+                        "flex-basis: 91.666667%;"
                     ],
                     [
                         "basis-full",
-                        "flex-basis: 100%;",
-                        ""
+                        "flex-basis: 100%;"
                     ]
                 ]
             },
@@ -8313,23 +7407,19 @@
                 "table": [
                     [
                         "flex-row",
-                        "flex-direction: row;",
-                        ""
+                        "flex-direction: row;"
                     ],
                     [
                         "flex-row-reverse",
-                        "flex-direction: row-reverse;",
-                        ""
+                        "flex-direction: row-reverse;"
                     ],
                     [
                         "flex-col",
-                        "flex-direction: column;",
-                        ""
+                        "flex-direction: column;"
                     ],
                     [
                         "flex-col-reverse",
-                        "flex-direction: column-reverse;",
-                        ""
+                        "flex-direction: column-reverse;"
                     ]
                 ]
             },
@@ -8340,18 +7430,15 @@
                 "table": [
                     [
                         "flex-nowrap",
-                        "flex-wrap: nowrap;",
-                        ""
+                        "flex-wrap: nowrap;"
                     ],
                     [
                         "flex-wrap",
-                        "flex-wrap: wrap;",
-                        ""
+                        "flex-wrap: wrap;"
                     ],
                     [
                         "flex-wrap-reverse",
-                        "flex-wrap: wrap-reverse;",
-                        ""
+                        "flex-wrap: wrap-reverse;"
                     ]
                 ]
             },
@@ -8362,23 +7449,19 @@
                 "table": [
                     [
                         "flex-1",
-                        "flex: 1 1 0%;",
-                        ""
+                        "flex: 1 1 0%;"
                     ],
                     [
                         "flex-auto",
-                        "flex: 1 1 auto;",
-                        ""
+                        "flex: 1 1 auto;"
                     ],
                     [
                         "flex-initial",
-                        "flex: 0 1 auto;",
-                        ""
+                        "flex: 0 1 auto;"
                     ],
                     [
                         "flex-none",
-                        "flex: none;",
-                        ""
+                        "flex: none;"
                     ]
                 ]
             },
@@ -8389,13 +7472,11 @@
                 "table": [
                     [
                         "flex-grow",
-                        "flex-grow: 1;",
-                        ""
+                        "flex-grow: 1;"
                     ],
                     [
                         "grow-0",
-                        "flex-grow: 0;",
-                        ""
+                        "flex-grow: 0;"
                     ]
                 ]
             },
@@ -8406,13 +7487,11 @@
                 "table": [
                     [
                         "shrink",
-                        "shrink: 1;",
-                        ""
+                        "shrink: 1;"
                     ],
                     [
                         "shrink-0",
-                        "shrink: 0;",
-                        ""
+                        "shrink: 0;"
                     ]
                 ]
             },
@@ -8423,78 +7502,63 @@
                 "table": [
                     [
                         "order-first",
-                        "order: -9999;",
-                        ""
+                        "order: -9999;"
                     ],
                     [
                         "order-last",
-                        "order: 9999;",
-                        ""
+                        "order: 9999;"
                     ],
                     [
                         "order-none",
-                        "order: 0;",
-                        ""
+                        "order: 0;"
                     ],
                     [
                         "order-1",
-                        "order: 1;",
-                        ""
+                        "order: 1;"
                     ],
                     [
                         "order-2",
-                        "order: 2;",
-                        ""
+                        "order: 2;"
                     ],
                     [
                         "order-3",
-                        "order: 3;",
-                        ""
+                        "order: 3;"
                     ],
                     [
                         "order-4",
-                        "order: 4;",
-                        ""
+                        "order: 4;"
                     ],
                     [
                         "order-5",
-                        "order: 5;",
-                        ""
+                        "order: 5;"
                     ],
                     [
                         "order-6",
-                        "order: 6;",
-                        ""
+                        "order: 6;"
                     ],
                     [
                         "order-7",
-                        "order: 7;",
-                        ""
+                        "order: 7;"
                     ],
                     [
                         "order-8",
-                        "order: 8;",
-                        ""
+                        "order: 8;"
                     ],
                     [
                         "order-9",
-                        "order: 9;",
-                        ""
+                        "order: 9;"
                     ],
                     [
                         "order-10",
-                        "order: 10;",
-                        ""
+                        "order: 10;"
                     ],
                     [
                         "order-11",
-                        "order: 11;",
-                        ""
+                        "order: 11;"
                     ],
                     [
                         "order-12",
-                        "order: 12;",
-                        ""
+                        "order: 12;"
                     ]
                 ]
             },
@@ -8505,68 +7569,55 @@
                 "table": [
                     [
                         "grid-cols-1",
-                        "grid-template-columns: repeat(1, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(1, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-2",
-                        "grid-template-columns: repeat(2, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(2, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-3",
-                        "grid-template-columns: repeat(3, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(3, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-4",
-                        "grid-template-columns: repeat(4, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(4, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-5",
-                        "grid-template-columns: repeat(5, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(5, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-6",
-                        "grid-template-columns: repeat(6, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(6, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-7",
-                        "grid-template-columns: repeat(7, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(7, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-8",
-                        "grid-template-columns: repeat(8, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(8, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-9",
-                        "grid-template-columns: repeat(9, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(9, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-10",
-                        "grid-template-columns: repeat(10, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(10, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-11",
-                        "grid-template-columns: repeat(11, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(11, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-12",
-                        "grid-template-columns: repeat(12, minmax(0, 1fr));",
-                        ""
+                        "grid-template-columns: repeat(12, minmax(0, 1fr));"
                     ],
                     [
                         "grid-cols-none",
-                        "grid-template-columns: none;",
-                        ""
+                        "grid-template-columns: none;"
                     ]
                 ]
             },
@@ -8577,208 +7628,167 @@
                 "table": [
                     [
                         "col-auto",
-                        "grid-column: auto;",
-                        ""
+                        "grid-column: auto;"
                     ],
                     [
                         "col-span-1",
-                        "grid-column: span 1 / span 1;",
-                        ""
+                        "grid-column: span 1 / span 1;"
                     ],
                     [
                         "col-span-2",
-                        "grid-column: span 2 / span 2;",
-                        ""
+                        "grid-column: span 2 / span 2;"
                     ],
                     [
                         "col-span-3",
-                        "grid-column: span 3 / span 3;",
-                        ""
+                        "grid-column: span 3 / span 3;"
                     ],
                     [
                         "col-span-4",
-                        "grid-column: span 4 / span 4;",
-                        ""
+                        "grid-column: span 4 / span 4;"
                     ],
                     [
                         "col-span-5",
-                        "grid-column: span 5 / span 5;",
-                        ""
+                        "grid-column: span 5 / span 5;"
                     ],
                     [
                         "col-span-6",
-                        "grid-column: span 6 / span 6;",
-                        ""
+                        "grid-column: span 6 / span 6;"
                     ],
                     [
                         "col-span-7",
-                        "grid-column: span 7 / span 7;",
-                        ""
+                        "grid-column: span 7 / span 7;"
                     ],
                     [
                         "col-span-8",
-                        "grid-column: span 8 / span 8;",
-                        ""
+                        "grid-column: span 8 / span 8;"
                     ],
                     [
                         "col-span-9",
-                        "grid-column: span 9 / span 9;",
-                        ""
+                        "grid-column: span 9 / span 9;"
                     ],
                     [
                         "col-span-10",
-                        "grid-column: span 10 / span 10;",
-                        ""
+                        "grid-column: span 10 / span 10;"
                     ],
                     [
                         "col-span-11",
-                        "grid-column: span 11 / span 11;",
-                        ""
+                        "grid-column: span 11 / span 11;"
                     ],
                     [
                         "col-span-12",
-                        "grid-column: span 12 / span 12;",
-                        ""
+                        "grid-column: span 12 / span 12;"
                     ],
                     [
                         "col-start-1",
-                        "grid-column-start: 1;",
-                        ""
+                        "grid-column-start: 1;"
                     ],
                     [
                         "col-start-2",
-                        "grid-column-start: 2;",
-                        ""
+                        "grid-column-start: 2;"
                     ],
                     [
                         "col-start-3",
-                        "grid-column-start: 3;",
-                        ""
+                        "grid-column-start: 3;"
                     ],
                     [
                         "col-start-4",
-                        "grid-column-start: 4;",
-                        ""
+                        "grid-column-start: 4;"
                     ],
                     [
                         "col-start-5",
-                        "grid-column-start: 5;",
-                        ""
+                        "grid-column-start: 5;"
                     ],
                     [
                         "col-start-6",
-                        "grid-column-start: 6;",
-                        ""
+                        "grid-column-start: 6;"
                     ],
                     [
                         "col-start-7",
-                        "grid-column-start: 7;",
-                        ""
+                        "grid-column-start: 7;"
                     ],
                     [
                         "col-start-8",
-                        "grid-column-start: 8;",
-                        ""
+                        "grid-column-start: 8;"
                     ],
                     [
                         "col-start-9",
-                        "grid-column-start: 9;",
-                        ""
+                        "grid-column-start: 9;"
                     ],
                     [
                         "col-start-10",
-                        "grid-column-start: 10;",
-                        ""
+                        "grid-column-start: 10;"
                     ],
                     [
                         "col-start-11",
-                        "grid-column-start: 11;",
-                        ""
+                        "grid-column-start: 11;"
                     ],
                     [
                         "col-start-12",
-                        "grid-column-start: 12;",
-                        ""
+                        "grid-column-start: 12;"
                     ],
                     [
                         "col-start-13",
-                        "grid-column-start: 13;",
-                        ""
+                        "grid-column-start: 13;"
                     ],
                     [
                         "col-start-auto",
-                        "grid-column-start: auto;",
-                        ""
+                        "grid-column-start: auto;"
                     ],
                     [
                         "col-end-1",
-                        "grid-column-end: 1;",
-                        ""
+                        "grid-column-end: 1;"
                     ],
                     [
                         "col-end-2",
-                        "grid-column-end: 2;",
-                        ""
+                        "grid-column-end: 2;"
                     ],
                     [
                         "col-end-3",
-                        "grid-column-end: 3;",
-                        ""
+                        "grid-column-end: 3;"
                     ],
                     [
                         "col-end-4",
-                        "grid-column-end: 4;",
-                        ""
+                        "grid-column-end: 4;"
                     ],
                     [
                         "col-end-5",
-                        "grid-column-end: 5;",
-                        ""
+                        "grid-column-end: 5;"
                     ],
                     [
                         "col-end-6",
-                        "grid-column-end: 6;",
-                        ""
+                        "grid-column-end: 6;"
                     ],
                     [
                         "col-end-7",
-                        "grid-column-end: 7;",
-                        ""
+                        "grid-column-end: 7;"
                     ],
                     [
                         "col-end-8",
-                        "grid-column-end: 8;",
-                        ""
+                        "grid-column-end: 8;"
                     ],
                     [
                         "col-end-9",
-                        "grid-column-end: 9;",
-                        ""
+                        "grid-column-end: 9;"
                     ],
                     [
                         "col-end-10",
-                        "grid-column-end: 10;",
-                        ""
+                        "grid-column-end: 10;"
                     ],
                     [
                         "col-end-11",
-                        "grid-column-end: 11;",
-                        ""
+                        "grid-column-end: 11;"
                     ],
                     [
                         "col-end-12",
-                        "grid-column-end: 12;",
-                        ""
+                        "grid-column-end: 12;"
                     ],
                     [
                         "col-end-13",
-                        "grid-column-end: 13;",
-                        ""
+                        "grid-column-end: 13;"
                     ],
                     [
                         "col-end-auto",
-                        "grid-column-end: auto;",
-                        ""
+                        "grid-column-end: auto;"
                     ]
                 ]
             },
@@ -8789,38 +7799,31 @@
                 "table": [
                     [
                         "grid-rows-1",
-                        "grid-template-rows: repeat(1, minmax(0, 1fr));",
-                        ""
+                        "grid-template-rows: repeat(1, minmax(0, 1fr));"
                     ],
                     [
                         "grid-rows-2",
-                        "grid-template-rows: repeat(2, minmax(0, 1fr));",
-                        ""
+                        "grid-template-rows: repeat(2, minmax(0, 1fr));"
                     ],
                     [
                         "grid-rows-3",
-                        "grid-template-rows: repeat(3, minmax(0, 1fr));",
-                        ""
+                        "grid-template-rows: repeat(3, minmax(0, 1fr));"
                     ],
                     [
                         "grid-rows-4",
-                        "grid-template-rows: repeat(4, minmax(0, 1fr));",
-                        ""
+                        "grid-template-rows: repeat(4, minmax(0, 1fr));"
                     ],
                     [
                         "grid-rows-5",
-                        "grid-template-rows: repeat(5, minmax(0, 1fr));",
-                        ""
+                        "grid-template-rows: repeat(5, minmax(0, 1fr));"
                     ],
                     [
                         "grid-rows-6",
-                        "grid-template-rows: repeat(6, minmax(0, 1fr));",
-                        ""
+                        "grid-template-rows: repeat(6, minmax(0, 1fr));"
                     ],
                     [
                         "grid-rows-none",
-                        "grid-template-rows: none;",
-                        ""
+                        "grid-template-rows: none;"
                     ]
                 ]
             },
@@ -8831,118 +7834,95 @@
                 "table": [
                     [
                         "row-auto",
-                        "grid-row: auto;",
-                        ""
+                        "grid-row: auto;"
                     ],
                     [
                         "row-span-1",
-                        "grid-row: span 1 / span 1;",
-                        ""
+                        "grid-row: span 1 / span 1;"
                     ],
                     [
                         "row-span-2",
-                        "grid-row: span 2 / span 2;",
-                        ""
+                        "grid-row: span 2 / span 2;"
                     ],
                     [
                         "row-span-3",
-                        "grid-row: span 3 / span 3;",
-                        ""
+                        "grid-row: span 3 / span 3;"
                     ],
                     [
                         "row-span-4",
-                        "grid-row: span 4 / span 4;",
-                        ""
+                        "grid-row: span 4 / span 4;"
                     ],
                     [
                         "row-span-5",
-                        "grid-row: span 5 / span 5;",
-                        ""
+                        "grid-row: span 5 / span 5;"
                     ],
                     [
                         "row-span-6",
-                        "grid-row: span 6 / span 6;",
-                        ""
+                        "grid-row: span 6 / span 6;"
                     ],
                     [
                         "row-start-1",
-                        "grid-row-start: 1;",
-                        ""
+                        "grid-row-start: 1;"
                     ],
                     [
                         "row-start-2",
-                        "grid-row-start: 2;",
-                        ""
+                        "grid-row-start: 2;"
                     ],
                     [
                         "row-start-3",
-                        "grid-row-start: 3;",
-                        ""
+                        "grid-row-start: 3;"
                     ],
                     [
                         "row-start-4",
-                        "grid-row-start: 4;",
-                        ""
+                        "grid-row-start: 4;"
                     ],
                     [
                         "row-start-5",
-                        "grid-row-start: 5;",
-                        ""
+                        "grid-row-start: 5;"
                     ],
                     [
                         "row-start-6",
-                        "grid-row-start: 6;",
-                        ""
+                        "grid-row-start: 6;"
                     ],
                     [
                         "row-start-7",
-                        "grid-row-start: 7;",
-                        ""
+                        "grid-row-start: 7;"
                     ],
                     [
                         "row-start-auto",
-                        "grid-row-start: auto;",
-                        ""
+                        "grid-row-start: auto;"
                     ],
                     [
                         "row-end-1",
-                        "grid-row-end: 1;",
-                        ""
+                        "grid-row-end: 1;"
                     ],
                     [
                         "row-end-2",
-                        "grid-row-end: 2;",
-                        ""
+                        "grid-row-end: 2;"
                     ],
                     [
                         "row-end-3",
-                        "grid-row-end: 3;",
-                        ""
+                        "grid-row-end: 3;"
                     ],
                     [
                         "row-end-4",
-                        "grid-row-end: 4;",
-                        ""
+                        "grid-row-end: 4;"
                     ],
                     [
                         "row-end-5",
-                        "grid-row-end: 5;",
-                        ""
+                        "grid-row-end: 5;"
                     ],
                     [
                         "row-end-6",
-                        "grid-row-end: 6;",
-                        ""
+                        "grid-row-end: 6;"
                     ],
                     [
                         "row-end-7",
-                        "grid-row-end: 7;",
-                        ""
+                        "grid-row-end: 7;"
                     ],
                     [
                         "row-end-auto",
-                        "grid-row-end: auto;",
-                        ""
+                        "grid-row-end: auto;"
                     ]
                 ]
             },
@@ -8953,23 +7933,19 @@
                 "table": [
                     [
                         "grid-flow-row",
-                        "grid-auto-flow: row;",
-                        ""
+                        "grid-auto-flow: row;"
                     ],
                     [
                         "grid-flow-col",
-                        "grid-auto-flow: column;",
-                        ""
+                        "grid-auto-flow: column;"
                     ],
                     [
                         "grid-flow-row-dense",
-                        "grid-auto-flow: row dense;",
-                        ""
+                        "grid-auto-flow: row dense;"
                     ],
                     [
                         "grid-flow-col-dense",
-                        "grid-auto-flow: column dense;",
-                        ""
+                        "grid-auto-flow: column dense;"
                     ]
                 ]
             },
@@ -8980,23 +7956,19 @@
                 "table": [
                     [
                         "auto-cols-auto",
-                        "grid-auto-columns: auto;",
-                        ""
+                        "grid-auto-columns: auto;"
                     ],
                     [
                         "auto-cols-min",
-                        "grid-auto-columns: min;",
-                        ""
+                        "grid-auto-columns: min;"
                     ],
                     [
                         "auto-cols-max",
-                        "grid-auto-columns: max;",
-                        ""
+                        "grid-auto-columns: max;"
                     ],
                     [
                         "auto-cols-fr",
-                        "grid-auto-columns: minmax(0, 1fr);",
-                        ""
+                        "grid-auto-columns: minmax(0, 1fr);"
                     ]
                 ]
             },
@@ -9007,23 +7979,19 @@
                 "table": [
                     [
                         "auto-rows-auto",
-                        "grid-auto-rows: auto;",
-                        ""
+                        "grid-auto-rows: auto;"
                     ],
                     [
                         "auto-rows-min",
-                        "grid-auto-rows: min;",
-                        ""
+                        "grid-auto-rows: min;"
                     ],
                     [
                         "auto-rows-max",
-                        "grid-auto-rows: max;",
-                        ""
+                        "grid-auto-rows: max;"
                     ],
                     [
                         "auto-rows-fr",
-                        "grid-auto-rows: minmax(0, 1fr);",
-                        ""
+                        "grid-auto-rows: minmax(0, 1fr);"
                     ]
                 ]
             },
@@ -9034,8 +8002,7 @@
                 "table": [
                     [
                         "gap-0",
-                        "gap: 0;",
-                        ""
+                        "gap: 0;"
                     ],
                     [
                         "gap-0.5",
@@ -9189,13 +8156,11 @@
                     ],
                     [
                         "gap-px",
-                        "gap: 1px;",
-                        ""
+                        "gap: 1px;"
                     ],
                     [
                         "gap-x-0",
-                        "column-gap: 0;",
-                        ""
+                        "column-gap: 0;"
                     ],
                     [
                         "gap-x-0.5",
@@ -9349,13 +8314,11 @@
                     ],
                     [
                         "gap-x-px",
-                        "column-gap: 1px;",
-                        ""
+                        "column-gap: 1px;"
                     ],
                     [
                         "gap-y-0",
-                        "row-gap: 0;",
-                        ""
+                        "row-gap: 0;"
                     ],
                     [
                         "gap-y-0.5",
@@ -9509,8 +8472,7 @@
                     ],
                     [
                         "gap-y-px",
-                        "row-gap: 1px;",
-                        ""
+                        "row-gap: 1px;"
                     ]
                 ]
             },
@@ -9521,33 +8483,27 @@
                 "table": [
                     [
                         "justify-start",
-                        "justify-content: flex-start;",
-                        ""
+                        "justify-content: flex-start;"
                     ],
                     [
                         "justify-center",
-                        "justify-content: center;",
-                        ""
+                        "justify-content: center;"
                     ],
                     [
                         "justify-end",
-                        "justify-content: flex-end;",
-                        ""
+                        "justify-content: flex-end;"
                     ],
                     [
                         "justify-between",
-                        "justify-content: space-between;",
-                        ""
+                        "justify-content: space-between;"
                     ],
                     [
                         "justify-around",
-                        "justify-content: space-around;",
-                        ""
+                        "justify-content: space-around;"
                     ],
                     [
                         "justify-evenly",
-                        "justify-content: space-evenly;",
-                        ""
+                        "justify-content: space-evenly;"
                     ]
                 ]
             },
@@ -9558,23 +8514,19 @@
                 "table": [
                     [
                         "justify-items-stretch",
-                        "justify-items: stretch;",
-                        ""
+                        "justify-items: stretch;"
                     ],
                     [
                         "justify-items-start",
-                        "justify-items: start;",
-                        ""
+                        "justify-items: start;"
                     ],
                     [
                         "justify-items-center",
-                        "justify-items: center;",
-                        ""
+                        "justify-items: center;"
                     ],
                     [
                         "justify-items-end",
-                        "justify-items: end;",
-                        ""
+                        "justify-items: end;"
                     ]
                 ]
             },
@@ -9585,28 +8537,23 @@
                 "table": [
                     [
                         "justify-self-stretch",
-                        "justify-self: stretch;",
-                        ""
+                        "justify-self: stretch;"
                     ],
                     [
                         "justify-self-start",
-                        "justify-self: start;",
-                        ""
+                        "justify-self: start;"
                     ],
                     [
                         "justify-self-center",
-                        "justify-self: center;",
-                        ""
+                        "justify-self: center;"
                     ],
                     [
                         "justify-self-end",
-                        "justify-self: end;",
-                        ""
+                        "justify-self: end;"
                     ],
                     [
                         "justify-self-auto",
-                        "justify-self: auto;",
-                        ""
+                        "justify-self: auto;"
                     ]
                 ]
             },
@@ -9617,33 +8564,27 @@
                 "table": [
                     [
                         "content-start",
-                        "align-content: flex-start;",
-                        ""
+                        "align-content: flex-start;"
                     ],
                     [
                         "content-center",
-                        "align-content: center;",
-                        ""
+                        "align-content: center;"
                     ],
                     [
                         "content-end",
-                        "align-content: flex-end;",
-                        ""
+                        "align-content: flex-end;"
                     ],
                     [
                         "content-between",
-                        "align-content: space-between;",
-                        ""
+                        "align-content: space-between;"
                     ],
                     [
                         "content-around",
-                        "align-content: space-around;",
-                        ""
+                        "align-content: space-around;"
                     ],
                     [
                         "content-evenly",
-                        "align-content: space-evenly;",
-                        ""
+                        "align-content: space-evenly;"
                     ]
                 ]
             },
@@ -9654,28 +8595,23 @@
                 "table": [
                     [
                         "items-stretch",
-                        "align-items: stretch;",
-                        ""
+                        "align-items: stretch;"
                     ],
                     [
                         "items-start",
-                        "align-items: flex-start;",
-                        ""
+                        "align-items: flex-start;"
                     ],
                     [
                         "items-center",
-                        "align-items: center;",
-                        ""
+                        "align-items: center;"
                     ],
                     [
                         "items-end",
-                        "align-items: flex-end;",
-                        ""
+                        "align-items: flex-end;"
                     ],
                     [
                         "items-baseline",
-                        "align-items: baseline;",
-                        ""
+                        "align-items: baseline;"
                     ]
                 ]
             },
@@ -9686,33 +8622,27 @@
                 "table": [
                     [
                         "self-auto",
-                        "align-self: auto;",
-                        ""
+                        "align-self: auto;"
                     ],
                     [
                         "self-start",
-                        "align-self: flex-start;",
-                        ""
+                        "align-self: flex-start;"
                     ],
                     [
                         "self-center",
-                        "align-self: center;",
-                        ""
+                        "align-self: center;"
                     ],
                     [
                         "self-end",
-                        "align-self: flex-end;",
-                        ""
+                        "align-self: flex-end;"
                     ],
                     [
                         "self-stretch",
-                        "align-self: stretch;",
-                        ""
+                        "align-self: stretch;"
                     ],
                     [
                         "self-baseline",
-                        "align-self: baseline;",
-                        ""
+                        "align-self: baseline;"
                     ]
                 ]
             },
@@ -9723,38 +8653,31 @@
                 "table": [
                     [
                         "place-content-start",
-                        "place-content: start;",
-                        ""
+                        "place-content: start;"
                     ],
                     [
                         "place-content-center",
-                        "place-content: center;",
-                        ""
+                        "place-content: center;"
                     ],
                     [
                         "place-content-end",
-                        "place-content: end;",
-                        ""
+                        "place-content: end;"
                     ],
                     [
                         "place-content-between",
-                        "place-content: space-between;",
-                        ""
+                        "place-content: space-between;"
                     ],
                     [
                         "place-content-around",
-                        "place-content: space-around;",
-                        ""
+                        "place-content: space-around;"
                     ],
                     [
                         "place-content-evenly",
-                        "place-content: space-evenly;",
-                        ""
+                        "place-content: space-evenly;"
                     ],
                     [
                         "place-content-stretch",
-                        "place-content: space-stretch;",
-                        ""
+                        "place-content: space-stretch;"
                     ]
                 ]
             },
@@ -9765,23 +8688,19 @@
                 "table": [
                     [
                         "place-items-stretch",
-                        "place-items: stretch;",
-                        ""
+                        "place-items: stretch;"
                     ],
                     [
                         "place-items-start",
-                        "place-items: start;",
-                        ""
+                        "place-items: start;"
                     ],
                     [
                         "place-items-center",
-                        "place-items: center;",
-                        ""
+                        "place-items: center;"
                     ],
                     [
                         "place-items-end",
-                        "place-items: end;",
-                        ""
+                        "place-items: end;"
                     ]
                 ]
             },
@@ -9792,28 +8711,23 @@
                 "table": [
                     [
                         "place-self-auto",
-                        "place-self: auto;",
-                        ""
+                        "place-self: auto;"
                     ],
                     [
                         "place-self-start",
-                        "place-self: start;",
-                        ""
+                        "place-self: start;"
                     ],
                     [
                         "place-self-center",
-                        "place-self: center;",
-                        ""
+                        "place-self: center;"
                     ],
                     [
                         "place-self-end",
-                        "place-self: end;",
-                        ""
+                        "place-self: end;"
                     ],
                     [
                         "place-self-stretch",
-                        "place-self: stretch;",
-                        ""
+                        "place-self: stretch;"
                     ]
                 ]
             }
@@ -9829,8 +8743,7 @@
                 "table": [
                     [
                         "rounded-none",
-                        "border-radius: 0;",
-                        ""
+                        "border-radius: 0;"
                     ],
                     [
                         "rounded-sm",
@@ -9869,28 +8782,23 @@
                     ],
                     [
                         "rounded-full",
-                        "border-radius: 9999px;",
-                        ""
+                        "border-radius: 9999px;"
                     ],
                     [
                         "rounded-t-none",
-                        "border-top-left-radius: 0;\nborder-top-right-radius: 0;",
-                        ""
+                        "border-top-left-radius: 0;\nborder-top-right-radius: 0;"
                     ],
                     [
                         "rounded-r-none",
-                        "border-top-right-radius: 0;\nborder-bottom-right-radius: 0;",
-                        ""
+                        "border-top-right-radius: 0;\nborder-bottom-right-radius: 0;"
                     ],
                     [
                         "rounded-b-none",
-                        "border-bottom-right-radius: 0;\nborder-bottom-left-radius: 0;",
-                        ""
+                        "border-bottom-right-radius: 0;\nborder-bottom-left-radius: 0;"
                     ],
                     [
                         "rounded-l-none",
-                        "border-top-left-radius: 0;\nborder-bottom-left-radius: 0;",
-                        ""
+                        "border-top-left-radius: 0;\nborder-bottom-left-radius: 0;"
                     ],
                     [
                         "rounded-t-sm",
@@ -10034,43 +8942,35 @@
                     ],
                     [
                         "rounded-t-full",
-                        "border-top-left-radius: 9999px;\nborder-top-right-radius: 9999px;",
-                        ""
+                        "border-top-left-radius: 9999px;\nborder-top-right-radius: 9999px;"
                     ],
                     [
                         "rounded-r-full",
-                        "border-top-right-radius: 9999px;\nborder-bottom-right-radius: 9999px;",
-                        ""
+                        "border-top-right-radius: 9999px;\nborder-bottom-right-radius: 9999px;"
                     ],
                     [
                         "rounded-b-full",
-                        "border-bottom-right-radius: 9999px;\nborder-bottom-left-radius: 9999px;",
-                        ""
+                        "border-bottom-right-radius: 9999px;\nborder-bottom-left-radius: 9999px;"
                     ],
                     [
                         "rounded-l-full",
-                        "border-top-left-radius: 9999px;\nborder-bottom-left-radius: 9999px;",
-                        ""
+                        "border-top-left-radius: 9999px;\nborder-bottom-left-radius: 9999px;"
                     ],
                     [
                         "rounded-tl-none",
-                        "border-top-left-radius: 0;",
-                        ""
+                        "border-top-left-radius: 0;"
                     ],
                     [
                         "rounded-tr-none",
-                        "border-top-right-radius: 0;",
-                        ""
+                        "border-top-right-radius: 0;"
                     ],
                     [
                         "rounded-br-none",
-                        "border-bottom-right-radius: 0;",
-                        ""
+                        "border-bottom-right-radius: 0;"
                     ],
                     [
                         "rounded-bl-none",
-                        "border-bottom-left-radius: 0;",
-                        ""
+                        "border-bottom-left-radius: 0;"
                     ],
                     [
                         "rounded-tl-sm",
@@ -10214,23 +9114,19 @@
                     ],
                     [
                         "rounded-tl-full",
-                        "border-top-left-radius: 9999px;",
-                        ""
+                        "border-top-left-radius: 9999px;"
                     ],
                     [
                         "rounded-tr-full",
-                        "border-top-right-radius: 9999px;",
-                        ""
+                        "border-top-right-radius: 9999px;"
                     ],
                     [
                         "rounded-br-full",
-                        "border-bottom-right-radius: 9999px;",
-                        ""
+                        "border-bottom-right-radius: 9999px;"
                     ],
                     [
                         "rounded-bl-full",
-                        "border-bottom-left-radius: 9999px;",
-                        ""
+                        "border-bottom-left-radius: 9999px;"
                     ]
                 ]
             },
@@ -10241,128 +9137,103 @@
                 "table": [
                     [
                         "border",
-                        "border-width: 1px;",
-                        ""
+                        "border-width: 1px;"
                     ],
                     [
                         "border-0",
-                        "border-width: 0;",
-                        ""
+                        "border-width: 0;"
                     ],
                     [
                         "border-2",
-                        "border-width: 2px;",
-                        ""
+                        "border-width: 2px;"
                     ],
                     [
                         "border-4",
-                        "border-width: 4px;",
-                        ""
+                        "border-width: 4px;"
                     ],
                     [
                         "border-8",
-                        "border-width: 8px;",
-                        ""
+                        "border-width: 8px;"
                     ],
                     [
                         "border-t",
-                        "border-top-width: 1px;",
-                        ""
+                        "border-top-width: 1px;"
                     ],
                     [
                         "border-t-0",
-                        "border-top-width: 0;",
-                        ""
+                        "border-top-width: 0;"
                     ],
                     [
                         "border-t-2",
-                        "border-top-width: 2px;",
-                        ""
+                        "border-top-width: 2px;"
                     ],
                     [
                         "border-t-4",
-                        "border-top-width: 4px;",
-                        ""
+                        "border-top-width: 4px;"
                     ],
                     [
                         "border-t-8",
-                        "border-top-width: 8px;",
-                        ""
+                        "border-top-width: 8px;"
                     ],
                     [
                         "border-r",
-                        "border-right-width: 1px;",
-                        ""
+                        "border-right-width: 1px;"
                     ],
                     [
                         "border-r-0",
-                        "border-right-width: 0;",
-                        ""
+                        "border-right-width: 0;"
                     ],
                     [
                         "border-r-2",
-                        "border-right-width: 2px;",
-                        ""
+                        "border-right-width: 2px;"
                     ],
                     [
                         "border-r-4",
-                        "border-right-width: 4px;",
-                        ""
+                        "border-right-width: 4px;"
                     ],
                     [
                         "border-r-8",
-                        "border-right-width: 8px;",
-                        ""
+                        "border-right-width: 8px;"
                     ],
                     [
                         "border-b",
-                        "border-bottom-width: 1px;",
-                        ""
+                        "border-bottom-width: 1px;"
                     ],
                     [
                         "border-b-0",
-                        "border-bottom-width: 0;",
-                        ""
+                        "border-bottom-width: 0;"
                     ],
                     [
                         "border-b-2",
-                        "border-bottom-width: 2px;",
-                        ""
+                        "border-bottom-width: 2px;"
                     ],
                     [
                         "border-b-4",
-                        "border-bottom-width: 4px;",
-                        ""
+                        "border-bottom-width: 4px;"
                     ],
                     [
                         "border-b-8",
-                        "border-bottom-width: 8px;",
-                        ""
+                        "border-bottom-width: 8px;"
                     ],
                     [
                         "border-l",
-                        "border-left-width: 1px;",
-                        ""
+                        "border-left-width: 1px;"
                     ],
                     [
                         "border-l-0",
-                        "border-left-width: 0;",
-                        ""
+                        "border-left-width: 0;"
                     ],
                     [
                         "border-l-2",
-                        "border-left-width: 2px;",
-                        ""
+                        "border-left-width: 2px;"
                     ],
                     [
                         "border-l-4",
-                        "border-left-width: 4px;",
-                        ""
+                        "border-left-width: 4px;"
                     ],
                     [
                         "border-l-8",
-                        "border-left-width: 8px;",
-                        ""
+                        "border-left-width: 8px;"
                     ]
                 ]
             },
@@ -10374,506 +9245,422 @@
                     [
                         "transparent",
                         "border-transparent",
-                        "border-color: transparent;",
-                        ""
+                        "border-color: transparent;"
                     ],
                     [
                         "current color",
                         "border-current",
-                        "border-color: currentColor;",
-                        ""
+                        "border-color: currentColor;"
                     ],
                     [
                         "rgb(0, 0, 0)",
                         "border-black",
-                        "border-color: #000000;",
-                        ""
+                        "border-color: #000000;"
                     ],
                     [
                         "rgb(255, 255, 255)",
                         "border-white",
-                        "border-color: #ffffff;",
-                        ""
+                        "border-color: #ffffff;"
                     ],
                     [
                         "rgb(249, 250, 251)",
                         "border-gray-50",
-                        "border-color: #F9FAFB;",
-                        ""
+                        "border-color: #F9FAFB;"
                     ],
                     [
                         "rgb(243, 244, 246)",
                         "border-gray-100",
-                        "border-color: #F3F4F6;",
-                        ""
+                        "border-color: #F3F4F6;"
                     ],
                     [
                         "rgb(229, 231, 235)",
                         "border-gray-200",
-                        "border-color: #E5E7EB;",
-                        ""
+                        "border-color: #E5E7EB;"
                     ],
                     [
                         "rgb(209, 213, 219)",
                         "border-gray-300",
-                        "border-color: #D1D5DB;",
-                        ""
+                        "border-color: #D1D5DB;"
                     ],
                     [
                         "rgb(156, 163, 175)",
                         "border-gray-400",
-                        "border-color: #9CA3AF;",
-                        ""
+                        "border-color: #9CA3AF;"
                     ],
                     [
                         "rgb(107, 114, 128)",
                         "border-gray-500",
-                        "border-color: #6B7280;",
-                        ""
+                        "border-color: #6B7280;"
                     ],
                     [
                         "rgb(75, 85, 99)",
                         "border-gray-600",
-                        "border-color: #4B5563;",
-                        ""
+                        "border-color: #4B5563;"
                     ],
                     [
                         "rgb(55, 65, 81)",
                         "border-gray-700",
-                        "border-color: #374151;",
-                        ""
+                        "border-color: #374151;"
                     ],
                     [
                         "rgb(31, 41, 55)",
                         "border-gray-800",
-                        "border-color: #1F2937;",
-                        ""
+                        "border-color: #1F2937;"
                     ],
                     [
                         "rgb(17, 24, 39)",
                         "border-gray-900",
-                        "border-color: #111827;",
-                        ""
+                        "border-color: #111827;"
                     ],
                     [
                         "rgb(254, 242, 242)",
                         "border-red-50",
-                        "border-color: #FEF2F2;",
-                        ""
+                        "border-color: #FEF2F2;"
                     ],
                     [
                         "rgb(254, 226, 226)",
                         "border-red-100",
-                        "border-color: #FEE2E2;",
-                        ""
+                        "border-color: #FEE2E2;"
                     ],
                     [
                         "rgb(254, 202, 202)",
                         "border-red-200",
-                        "border-color: #FECACA;",
-                        ""
+                        "border-color: #FECACA;"
                     ],
                     [
                         "rgb(252, 165, 165)",
                         "border-red-300",
-                        "border-color: #FCA5A5;",
-                        ""
+                        "border-color: #FCA5A5;"
                     ],
                     [
                         "rgb(248, 113, 113)",
                         "border-red-400",
-                        "border-color: #F87171;",
-                        ""
+                        "border-color: #F87171;"
                     ],
                     [
                         "rgb(239, 68, 68)",
                         "border-red-500",
-                        "border-color: #EF4444;",
-                        ""
+                        "border-color: #EF4444;"
                     ],
                     [
                         "rgb(220, 38, 38)",
                         "border-red-600",
-                        "border-color: #DC2626;",
-                        ""
+                        "border-color: #DC2626;"
                     ],
                     [
                         "rgb(185, 28, 28)",
                         "border-red-700",
-                        "border-color: #B91C1C;",
-                        ""
+                        "border-color: #B91C1C;"
                     ],
                     [
                         "rgb(153, 27, 27)",
                         "border-red-800",
-                        "border-color: #991B1B;",
-                        ""
+                        "border-color: #991B1B;"
                     ],
                     [
                         "rgb(127, 29, 29)",
                         "border-red-900",
-                        "border-color: #7F1D1D;",
-                        ""
+                        "border-color: #7F1D1D;"
                     ],
                     [
                         "rgb(255, 251, 235)",
                         "border-yellow-50",
-                        "border-color: #FFFBEB;",
-                        ""
+                        "border-color: #FFFBEB;"
                     ],
                     [
                         "rgb(254, 243, 199)",
                         "border-yellow-100",
-                        "border-color: #FEF3C7;",
-                        ""
+                        "border-color: #FEF3C7;"
                     ],
                     [
                         "rgb(253, 230, 138)",
                         "border-yellow-200",
-                        "border-color: #FDE68A;",
-                        ""
+                        "border-color: #FDE68A;"
                     ],
                     [
                         "rgb(252, 211, 77)",
                         "border-yellow-300",
-                        "border-color: #FCD34D;",
-                        ""
+                        "border-color: #FCD34D;"
                     ],
                     [
                         "rgb(251, 191, 36)",
                         "border-yellow-400",
-                        "border-color: #FBBF24;",
-                        ""
+                        "border-color: #FBBF24;"
                     ],
                     [
                         "rgb(245, 158, 11)",
                         "border-yellow-500",
-                        "border-color: #F59E0B;",
-                        ""
+                        "border-color: #F59E0B;"
                     ],
                     [
                         "rgb(217, 119, 6)",
                         "border-yellow-600",
-                        "border-color: #D97706;",
-                        ""
+                        "border-color: #D97706;"
                     ],
                     [
                         "rgb(180, 83, 9)",
                         "border-yellow-700",
-                        "border-color: #B45309;",
-                        ""
+                        "border-color: #B45309;"
                     ],
                     [
                         "rgb(146, 64, 14)",
                         "border-yellow-800",
-                        "border-color: #92400E;",
-                        ""
+                        "border-color: #92400E;"
                     ],
                     [
                         "rgb(120, 53, 15)",
                         "border-yellow-900",
-                        "border-color: #78350F;",
-                        ""
+                        "border-color: #78350F;"
                     ],
                     [
                         "rgb(236, 253, 245)",
                         "border-green-50",
-                        "border-color: #ECFDF5;",
-                        ""
+                        "border-color: #ECFDF5;"
                     ],
                     [
                         "rgb(209, 250, 229)",
                         "border-green-100",
-                        "border-color: #D1FAE5;",
-                        ""
+                        "border-color: #D1FAE5;"
                     ],
                     [
                         "rgb(167, 243, 208)",
                         "border-green-200",
-                        "border-color: #A7F3D0;",
-                        ""
+                        "border-color: #A7F3D0;"
                     ],
                     [
                         "rgb(110, 231, 183)",
                         "border-green-300",
-                        "border-color: #6EE7B7;",
-                        ""
+                        "border-color: #6EE7B7;"
                     ],
                     [
                         "rgb(52, 211, 153)",
                         "border-green-400",
-                        "border-color: #34D399;",
-                        ""
+                        "border-color: #34D399;"
                     ],
                     [
                         "rgb(16, 185, 129)",
                         "border-green-500",
-                        "border-color: #10B981;",
-                        ""
+                        "border-color: #10B981;"
                     ],
                     [
                         "rgb(5, 150, 105)",
                         "border-green-600",
-                        "border-color: #059669;",
-                        ""
+                        "border-color: #059669;"
                     ],
                     [
                         "rgb(4, 120, 87)",
                         "border-green-700",
-                        "border-color: #047857;",
-                        ""
+                        "border-color: #047857;"
                     ],
                     [
                         "rgb(6, 95, 70)",
                         "border-green-800",
-                        "border-color: #065F46;",
-                        ""
+                        "border-color: #065F46;"
                     ],
                     [
                         "rgb(6, 78, 59)",
                         "border-green-900",
-                        "border-color: #064E3B;",
-                        ""
+                        "border-color: #064E3B;"
                     ],
                     [
                         "rgb(239, 246, 255)",
                         "border-blue-50",
-                        "border-color: #EFF6FF;",
-                        ""
+                        "border-color: #EFF6FF;"
                     ],
                     [
                         "rgb(219, 234, 254)",
                         "border-blue-100",
-                        "border-color: #DBEAFE;",
-                        ""
+                        "border-color: #DBEAFE;"
                     ],
                     [
                         "rgb(191, 219, 254)",
                         "border-blue-200",
-                        "border-color: #BFDBFE;",
-                        ""
+                        "border-color: #BFDBFE;"
                     ],
                     [
                         "rgb(147, 197, 253)",
                         "border-blue-300",
-                        "border-color: #93C5FD;",
-                        ""
+                        "border-color: #93C5FD;"
                     ],
                     [
                         "rgb(96, 165, 250)",
                         "border-blue-400",
-                        "border-color: #60A5FA;",
-                        ""
+                        "border-color: #60A5FA;"
                     ],
                     [
                         "rgb(59, 130, 246)",
                         "border-blue-500",
-                        "border-color: #3B82F6;",
-                        ""
+                        "border-color: #3B82F6;"
                     ],
                     [
                         "rgb(37, 99, 235)",
                         "border-blue-600",
-                        "border-color: #2563EB;",
-                        ""
+                        "border-color: #2563EB;"
                     ],
                     [
                         "rgb(29, 78, 216)",
                         "border-blue-700",
-                        "border-color: #1D4ED8;",
-                        ""
+                        "border-color: #1D4ED8;"
                     ],
                     [
                         "rgb(30, 64, 175)",
                         "border-blue-800",
-                        "border-color: #1E40AF;",
-                        ""
+                        "border-color: #1E40AF;"
                     ],
                     [
                         "rgb(30, 58, 138)",
                         "border-blue-900",
-                        "border-color: #1E3A8A;",
-                        ""
+                        "border-color: #1E3A8A;"
                     ],
                     [
                         "rgb(238, 242, 255)",
                         "border-indigo-50",
-                        "border-color: #EEF2FF;",
-                        ""
+                        "border-color: #EEF2FF;"
                     ],
                     [
                         "rgb(224, 231, 255)",
                         "border-indigo-100",
-                        "border-color: #E0E7FF;",
-                        ""
+                        "border-color: #E0E7FF;"
                     ],
                     [
                         "rgb(199, 210, 254)",
                         "border-indigo-200",
-                        "border-color: #C7D2FE;",
-                        ""
+                        "border-color: #C7D2FE;"
                     ],
                     [
                         "rgb(165, 180, 252)",
                         "border-indigo-300",
-                        "border-color: #A5B4FC;",
-                        ""
+                        "border-color: #A5B4FC;"
                     ],
                     [
                         "rgb(129, 140, 248)",
                         "border-indigo-400",
-                        "border-color: #818CF8;",
-                        ""
+                        "border-color: #818CF8;"
                     ],
                     [
                         "rgb(99, 102, 241)",
                         "border-indigo-500",
-                        "border-color: #6366F1;",
-                        ""
+                        "border-color: #6366F1;"
                     ],
                     [
                         "rgb(79, 70, 229)",
                         "border-indigo-600",
-                        "border-color: #4F46E5;",
-                        ""
+                        "border-color: #4F46E5;"
                     ],
                     [
                         "rgb(67, 56, 202)",
                         "border-indigo-700",
-                        "border-color: #4338CA;",
-                        ""
+                        "border-color: #4338CA;"
                     ],
                     [
                         "rgb(55, 48, 163)",
                         "border-indigo-800",
-                        "border-color: #3730A3;",
-                        ""
+                        "border-color: #3730A3;"
                     ],
                     [
                         "rgb(49, 46, 129)",
                         "border-indigo-900",
-                        "border-color: #312E81;",
-                        ""
+                        "border-color: #312E81;"
                     ],
                     [
                         "rgb(245, 243, 255)",
                         "border-purple-50",
-                        "border-color: #F5F3FF;",
-                        ""
+                        "border-color: #F5F3FF;"
                     ],
                     [
                         "rgb(237, 233, 254)",
                         "border-purple-100",
-                        "border-color: #EDE9FE;",
-                        ""
+                        "border-color: #EDE9FE;"
                     ],
                     [
                         "rgb(221, 214, 254)",
                         "border-purple-200",
-                        "border-color: #DDD6FE;",
-                        ""
+                        "border-color: #DDD6FE;"
                     ],
                     [
                         "rgb(196, 181, 253)",
                         "border-purple-300",
-                        "border-color: #C4B5FD;",
-                        ""
+                        "border-color: #C4B5FD;"
                     ],
                     [
                         "rgb(167, 139, 250)",
                         "border-purple-400",
-                        "border-color: #A78BFA;",
-                        ""
+                        "border-color: #A78BFA;"
                     ],
                     [
                         "rgb(139, 92, 246)",
                         "border-purple-500",
-                        "border-color: #8B5CF6;",
-                        ""
+                        "border-color: #8B5CF6;"
                     ],
                     [
                         "rgb(124, 58, 237)",
                         "border-purple-600",
-                        "border-color: #7C3AED;",
-                        ""
+                        "border-color: #7C3AED;"
                     ],
                     [
                         "rgb(109, 40, 217)",
                         "border-purple-700",
-                        "border-color: #6D28D9;",
-                        ""
+                        "border-color: #6D28D9;"
                     ],
                     [
                         "rgb(91, 33, 182)",
                         "border-purple-800",
-                        "border-color: #5B21B6;",
-                        ""
+                        "border-color: #5B21B6;"
                     ],
                     [
                         "rgb(76, 29, 149)",
                         "border-purple-900",
-                        "border-color: #4C1D95;",
-                        ""
+                        "border-color: #4C1D95;"
                     ],
                     [
                         "rgb(253, 242, 248)",
                         "border-pink-50",
-                        "border-color: #FDF2F8;",
-                        ""
+                        "border-color: #FDF2F8;"
                     ],
                     [
                         "rgb(252, 231, 243)",
                         "border-pink-100",
-                        "border-color: #FCE7F3;",
-                        ""
+                        "border-color: #FCE7F3;"
                     ],
                     [
                         "rgb(251, 207, 232)",
                         "border-pink-200",
-                        "border-color: #FBCFE8;",
-                        ""
+                        "border-color: #FBCFE8;"
                     ],
                     [
                         "rgb(249, 168, 212)",
                         "border-pink-300",
-                        "border-color: #F9A8D4;",
-                        ""
+                        "border-color: #F9A8D4;"
                     ],
                     [
                         "rgb(244, 114, 182)",
                         "border-pink-400",
-                        "border-color: #F472B6;",
-                        ""
+                        "border-color: #F472B6;"
                     ],
                     [
                         "rgb(236, 72, 153)",
                         "border-pink-500",
-                        "border-color: #EC4899;",
-                        ""
+                        "border-color: #EC4899;"
                     ],
                     [
                         "rgb(219, 39, 119)",
                         "border-pink-600",
-                        "border-color: #DB2777;",
-                        ""
+                        "border-color: #DB2777;"
                     ],
                     [
                         "rgb(190, 24, 93)",
                         "border-pink-700",
-                        "border-color: #BE185D;",
-                        ""
+                        "border-color: #BE185D;"
                     ],
                     [
                         "rgb(157, 23, 77)",
                         "border-pink-800",
-                        "border-color: #9D174D;",
-                        ""
+                        "border-color: #9D174D;"
                     ],
                     [
                         "rgb(131, 24, 67)",
                         "border-pink-900",
-                        "border-color: #831843;",
-                        ""
+                        "border-color: #831843;"
                     ]
                 ]
             },
@@ -10884,73 +9671,59 @@
                 "table": [
                     [
                         "border-opacity-0",
-                        "border-opacity: 0;",
-                        ""
+                        "border-opacity: 0;"
                     ],
                     [
                         "border-opacity-5",
-                        "border-opacity: 0.05;",
-                        ""
+                        "border-opacity: 0.05;"
                     ],
                     [
                         "border-opacity-10",
-                        "border-opacity: 0.1;",
-                        ""
+                        "border-opacity: 0.1;"
                     ],
                     [
                         "border-opacity-20",
-                        "border-opacity: 0.2;",
-                        ""
+                        "border-opacity: 0.2;"
                     ],
                     [
                         "border-opacity-25",
-                        "border-opacity: 0.25;",
-                        ""
+                        "border-opacity: 0.25;"
                     ],
                     [
                         "border-opacity-30",
-                        "border-opacity: 0.3;",
-                        ""
+                        "border-opacity: 0.3;"
                     ],
                     [
                         "border-opacity-40",
-                        "border-opacity: 0.4;",
-                        ""
+                        "border-opacity: 0.4;"
                     ],
                     [
                         "border-opacity-50",
-                        "border-opacity: 0.5;",
-                        ""
+                        "border-opacity: 0.5;"
                     ],
                     [
                         "border-opacity-60",
-                        "border-opacity: 0.6;",
-                        ""
+                        "border-opacity: 0.6;"
                     ],
                     [
                         "border-opacity-70",
-                        "border-opacity: 0.7;",
-                        ""
+                        "border-opacity: 0.7;"
                     ],
                     [
                         "border-opacity-75",
-                        "border-opacity: 0.75;",
-                        ""
+                        "border-opacity: 0.75;"
                     ],
                     [
                         "border-opacity-80",
-                        "border-opacity: 0.8;",
-                        ""
+                        "border-opacity: 0.8;"
                     ],
                     [
                         "border-opacity-90",
-                        "border-opacity: 0.9;",
-                        ""
+                        "border-opacity: 0.9;"
                     ],
                     [
                         "border-opacity-100",
-                        "border-opacity: 1;",
-                        ""
+                        "border-opacity: 1;"
                     ]
                 ]
             },
@@ -10961,33 +9734,27 @@
                 "table": [
                     [
                         "border-solid",
-                        "border-style: solid;",
-                        ""
+                        "border-style: solid;"
                     ],
                     [
                         "border-dashed",
-                        "border-style: dashed;",
-                        ""
+                        "border-style: dashed;"
                     ],
                     [
                         "border-dotted",
-                        "border-style: dotted;",
-                        ""
+                        "border-style: dotted;"
                     ],
                     [
                         "border-double",
-                        "border-style: double;",
-                        ""
+                        "border-style: double;"
                     ],
                     [
                         "border-hidden",
-                        "border-style: hidden;",
-                        ""
+                        "border-style: hidden;"
                     ],
                     [
                         "border-none",
-                        "border-style: none;",
-                        ""
+                        "border-style: none;"
                     ]
                 ]
             },
@@ -10998,63 +9765,51 @@
                 "table": [
                     [
                         "divide-x-0",
-                        "border-left-width: 0;",
-                        ""
+                        "border-left-width: 0;"
                     ],
                     [
                         "divide-x-2",
-                        "border-left-width: 2px;",
-                        ""
+                        "border-left-width: 2px;"
                     ],
                     [
                         "divide-x-4",
-                        "border-left-width: 4px;",
-                        ""
+                        "border-left-width: 4px;"
                     ],
                     [
                         "divide-x-8",
-                        "border-left-width: 8px;",
-                        ""
+                        "border-left-width: 8px;"
                     ],
                     [
                         "divide-x",
-                        "border-left-width: 1px;",
-                        ""
+                        "border-left-width: 1px;"
                     ],
                     [
                         "divide-y-0",
-                        "border-top-width: 0;",
-                        ""
+                        "border-top-width: 0;"
                     ],
                     [
                         "divide-y-2",
-                        "border-top-width: 2px;",
-                        ""
+                        "border-top-width: 2px;"
                     ],
                     [
                         "divide-y-4",
-                        "border-top-width: 4px;",
-                        ""
+                        "border-top-width: 4px;"
                     ],
                     [
                         "divide-y-8",
-                        "border-top-width: 8px;",
-                        ""
+                        "border-top-width: 8px;"
                     ],
                     [
                         "divide-y",
-                        "border-top-width: 1px;",
-                        ""
+                        "border-top-width: 1px;"
                     ],
                     [
                         "divide-x-reverse",
-                        "--divide-x-reverse: 1",
-                        ""
+                        "--divide-x-reverse: 1"
                     ],
                     [
                         "divide-y-reverse",
-                        "--divide-y-reverse: 1",
-                        ""
+                        "--divide-y-reverse: 1"
                     ]
                 ]
             },
@@ -11066,506 +9821,422 @@
                     [
                         "transparent",
                         "divide-transparent",
-                        "border-color: transparent;",
-                        ""
+                        "border-color: transparent;"
                     ],
                     [
                         "current color",
                         "divide-current",
-                        "border-color: currentColor;",
-                        ""
+                        "border-color: currentColor;"
                     ],
                     [
                         "rgb(0, 0, 0)",
                         "divide-black",
-                        "border-color: #000000;",
-                        ""
+                        "border-color: #000000;"
                     ],
                     [
                         "rgb(255, 255, 255)",
                         "divide-white",
-                        "border-color: #ffffff;",
-                        ""
+                        "border-color: #ffffff;"
                     ],
                     [
                         "rgb(249, 250, 251)",
                         "divide-gray-50",
-                        "border-color: #F9FAFB;",
-                        ""
+                        "border-color: #F9FAFB;"
                     ],
                     [
                         "rgb(243, 244, 246)",
                         "divide-gray-100",
-                        "border-color: #F3F4F6;",
-                        ""
+                        "border-color: #F3F4F6;"
                     ],
                     [
                         "rgb(229, 231, 235)",
                         "divide-gray-200",
-                        "border-color: #E5E7EB;",
-                        ""
+                        "border-color: #E5E7EB;"
                     ],
                     [
                         "rgb(209, 213, 219)",
                         "divide-gray-300",
-                        "border-color: #D1D5DB;",
-                        ""
+                        "border-color: #D1D5DB;"
                     ],
                     [
                         "rgb(156, 163, 175)",
                         "divide-gray-400",
-                        "border-color: #9CA3AF;",
-                        ""
+                        "border-color: #9CA3AF;"
                     ],
                     [
                         "rgb(107, 114, 128)",
                         "divide-gray-500",
-                        "border-color: #6B7280;",
-                        ""
+                        "border-color: #6B7280;"
                     ],
                     [
                         "rgb(75, 85, 99)",
                         "divide-gray-600",
-                        "border-color: #4B5563;",
-                        ""
+                        "border-color: #4B5563;"
                     ],
                     [
                         "rgb(55, 65, 81)",
                         "divide-gray-700",
-                        "border-color: #374151;",
-                        ""
+                        "border-color: #374151;"
                     ],
                     [
                         "rgb(31, 41, 55)",
                         "divide-gray-800",
-                        "border-color: #1F2937;",
-                        ""
+                        "border-color: #1F2937;"
                     ],
                     [
                         "rgb(17, 24, 39)",
                         "divide-gray-900",
-                        "border-color: #111827;",
-                        ""
+                        "border-color: #111827;"
                     ],
                     [
                         "rgb(254, 242, 242)",
                         "divide-red-50",
-                        "border-color: #FEF2F2;",
-                        ""
+                        "border-color: #FEF2F2;"
                     ],
                     [
                         "rgb(254, 226, 226)",
                         "divide-red-100",
-                        "border-color: #FEE2E2;",
-                        ""
+                        "border-color: #FEE2E2;"
                     ],
                     [
                         "rgb(254, 202, 202)",
                         "divide-red-200",
-                        "border-color: #FECACA;",
-                        ""
+                        "border-color: #FECACA;"
                     ],
                     [
                         "rgb(252, 165, 165)",
                         "divide-red-300",
-                        "border-color: #FCA5A5;",
-                        ""
+                        "border-color: #FCA5A5;"
                     ],
                     [
                         "rgb(248, 113, 113)",
                         "divide-red-400",
-                        "border-color: #F87171;",
-                        ""
+                        "border-color: #F87171;"
                     ],
                     [
                         "rgb(239, 68, 68)",
                         "divide-red-500",
-                        "border-color: #EF4444;",
-                        ""
+                        "border-color: #EF4444;"
                     ],
                     [
                         "rgb(220, 38, 38)",
                         "divide-red-600",
-                        "border-color: #DC2626;",
-                        ""
+                        "border-color: #DC2626;"
                     ],
                     [
                         "rgb(185, 28, 28)",
                         "divide-red-700",
-                        "border-color: #B91C1C;",
-                        ""
+                        "border-color: #B91C1C;"
                     ],
                     [
                         "rgb(153, 27, 27)",
                         "divide-red-800",
-                        "border-color: #991B1B;",
-                        ""
+                        "border-color: #991B1B;"
                     ],
                     [
                         "rgb(127, 29, 29)",
                         "divide-red-900",
-                        "border-color: #7F1D1D;",
-                        ""
+                        "border-color: #7F1D1D;"
                     ],
                     [
                         "rgb(255, 251, 235)",
                         "divide-yellow-50",
-                        "border-color: #FFFBEB;",
-                        ""
+                        "border-color: #FFFBEB;"
                     ],
                     [
                         "rgb(254, 243, 199)",
                         "divide-yellow-100",
-                        "border-color: #FEF3C7;",
-                        ""
+                        "border-color: #FEF3C7;"
                     ],
                     [
                         "rgb(253, 230, 138)",
                         "divide-yellow-200",
-                        "border-color: #FDE68A;",
-                        ""
+                        "border-color: #FDE68A;"
                     ],
                     [
                         "rgb(252, 211, 77)",
                         "divide-yellow-300",
-                        "border-color: #FCD34D;",
-                        ""
+                        "border-color: #FCD34D;"
                     ],
                     [
                         "rgb(251, 191, 36)",
                         "divide-yellow-400",
-                        "border-color: #FBBF24;",
-                        ""
+                        "border-color: #FBBF24;"
                     ],
                     [
                         "rgb(245, 158, 11)",
                         "divide-yellow-500",
-                        "border-color: #F59E0B;",
-                        ""
+                        "border-color: #F59E0B;"
                     ],
                     [
                         "rgb(217, 119, 6)",
                         "divide-yellow-600",
-                        "border-color: #D97706;",
-                        ""
+                        "border-color: #D97706;"
                     ],
                     [
                         "rgb(180, 83, 9)",
                         "divide-yellow-700",
-                        "border-color: #B45309;",
-                        ""
+                        "border-color: #B45309;"
                     ],
                     [
                         "rgb(146, 64, 14)",
                         "divide-yellow-800",
-                        "border-color: #92400E;",
-                        ""
+                        "border-color: #92400E;"
                     ],
                     [
                         "rgb(120, 53, 15)",
                         "divide-yellow-900",
-                        "border-color: #78350F;",
-                        ""
+                        "border-color: #78350F;"
                     ],
                     [
                         "rgb(236, 253, 245)",
                         "divide-green-50",
-                        "border-color: #ECFDF5;",
-                        ""
+                        "border-color: #ECFDF5;"
                     ],
                     [
                         "rgb(209, 250, 229)",
                         "divide-green-100",
-                        "border-color: #D1FAE5;",
-                        ""
+                        "border-color: #D1FAE5;"
                     ],
                     [
                         "rgb(167, 243, 208)",
                         "divide-green-200",
-                        "border-color: #A7F3D0;",
-                        ""
+                        "border-color: #A7F3D0;"
                     ],
                     [
                         "rgb(110, 231, 183)",
                         "divide-green-300",
-                        "border-color: #6EE7B7;",
-                        ""
+                        "border-color: #6EE7B7;"
                     ],
                     [
                         "rgb(52, 211, 153)",
                         "divide-green-400",
-                        "border-color: #34D399;",
-                        ""
+                        "border-color: #34D399;"
                     ],
                     [
                         "rgb(16, 185, 129)",
                         "divide-green-500",
-                        "border-color: #10B981;",
-                        ""
+                        "border-color: #10B981;"
                     ],
                     [
                         "rgb(5, 150, 105)",
                         "divide-green-600",
-                        "border-color: #059669;",
-                        ""
+                        "border-color: #059669;"
                     ],
                     [
                         "rgb(4, 120, 87)",
                         "divide-green-700",
-                        "border-color: #047857;",
-                        ""
+                        "border-color: #047857;"
                     ],
                     [
                         "rgb(6, 95, 70)",
                         "divide-green-800",
-                        "border-color: #065F46;",
-                        ""
+                        "border-color: #065F46;"
                     ],
                     [
                         "rgb(6, 78, 59)",
                         "divide-green-900",
-                        "border-color: #064E3B;",
-                        ""
+                        "border-color: #064E3B;"
                     ],
                     [
                         "rgb(239, 246, 255)",
                         "divide-blue-50",
-                        "border-color: #EFF6FF;",
-                        ""
+                        "border-color: #EFF6FF;"
                     ],
                     [
                         "rgb(219, 234, 254)",
                         "divide-blue-100",
-                        "border-color: #DBEAFE;",
-                        ""
+                        "border-color: #DBEAFE;"
                     ],
                     [
                         "rgb(191, 219, 254)",
                         "divide-blue-200",
-                        "border-color: #BFDBFE;",
-                        ""
+                        "border-color: #BFDBFE;"
                     ],
                     [
                         "rgb(147, 197, 253)",
                         "divide-blue-300",
-                        "border-color: #93C5FD;",
-                        ""
+                        "border-color: #93C5FD;"
                     ],
                     [
                         "rgb(96, 165, 250)",
                         "divide-blue-400",
-                        "border-color: #60A5FA;",
-                        ""
+                        "border-color: #60A5FA;"
                     ],
                     [
                         "rgb(59, 130, 246)",
                         "divide-blue-500",
-                        "border-color: #3B82F6;",
-                        ""
+                        "border-color: #3B82F6;"
                     ],
                     [
                         "rgb(37, 99, 235)",
                         "divide-blue-600",
-                        "border-color: #2563EB;",
-                        ""
+                        "border-color: #2563EB;"
                     ],
                     [
                         "rgb(29, 78, 216)",
                         "divide-blue-700",
-                        "border-color: #1D4ED8;",
-                        ""
+                        "border-color: #1D4ED8;"
                     ],
                     [
                         "rgb(30, 64, 175)",
                         "divide-blue-800",
-                        "border-color: #1E40AF;",
-                        ""
+                        "border-color: #1E40AF;"
                     ],
                     [
                         "rgb(30, 58, 138)",
                         "divide-blue-900",
-                        "border-color: #1E3A8A;",
-                        ""
+                        "border-color: #1E3A8A;"
                     ],
                     [
                         "rgb(238, 242, 255)",
                         "divide-indigo-50",
-                        "border-color: #EEF2FF;",
-                        ""
+                        "border-color: #EEF2FF;"
                     ],
                     [
                         "rgb(224, 231, 255)",
                         "divide-indigo-100",
-                        "border-color: #E0E7FF;",
-                        ""
+                        "border-color: #E0E7FF;"
                     ],
                     [
                         "rgb(199, 210, 254)",
                         "divide-indigo-200",
-                        "border-color: #C7D2FE;",
-                        ""
+                        "border-color: #C7D2FE;"
                     ],
                     [
                         "rgb(165, 180, 252)",
                         "divide-indigo-300",
-                        "border-color: #A5B4FC;",
-                        ""
+                        "border-color: #A5B4FC;"
                     ],
                     [
                         "rgb(129, 140, 248)",
                         "divide-indigo-400",
-                        "border-color: #818CF8;",
-                        ""
+                        "border-color: #818CF8;"
                     ],
                     [
                         "rgb(99, 102, 241)",
                         "divide-indigo-500",
-                        "border-color: #6366F1;",
-                        ""
+                        "border-color: #6366F1;"
                     ],
                     [
                         "rgb(79, 70, 229)",
                         "divide-indigo-600",
-                        "border-color: #4F46E5;",
-                        ""
+                        "border-color: #4F46E5;"
                     ],
                     [
                         "rgb(67, 56, 202)",
                         "divide-indigo-700",
-                        "border-color: #4338CA;",
-                        ""
+                        "border-color: #4338CA;"
                     ],
                     [
                         "rgb(55, 48, 163)",
                         "divide-indigo-800",
-                        "border-color: #3730A3;",
-                        ""
+                        "border-color: #3730A3;"
                     ],
                     [
                         "rgb(49, 46, 129)",
                         "divide-indigo-900",
-                        "border-color: #312E81;",
-                        ""
+                        "border-color: #312E81;"
                     ],
                     [
                         "rgb(245, 243, 255)",
                         "divide-purple-50",
-                        "border-color: #F5F3FF;",
-                        ""
+                        "border-color: #F5F3FF;"
                     ],
                     [
                         "rgb(237, 233, 254)",
                         "divide-purple-100",
-                        "border-color: #EDE9FE;",
-                        ""
+                        "border-color: #EDE9FE;"
                     ],
                     [
                         "rgb(221, 214, 254)",
                         "divide-purple-200",
-                        "border-color: #DDD6FE;",
-                        ""
+                        "border-color: #DDD6FE;"
                     ],
                     [
                         "rgb(196, 181, 253)",
                         "divide-purple-300",
-                        "border-color: #C4B5FD;",
-                        ""
+                        "border-color: #C4B5FD;"
                     ],
                     [
                         "rgb(167, 139, 250)",
                         "divide-purple-400",
-                        "border-color: #A78BFA;",
-                        ""
+                        "border-color: #A78BFA;"
                     ],
                     [
                         "rgb(139, 92, 246)",
                         "divide-purple-500",
-                        "border-color: #8B5CF6;",
-                        ""
+                        "border-color: #8B5CF6;"
                     ],
                     [
                         "rgb(124, 58, 237)",
                         "divide-purple-600",
-                        "border-color: #7C3AED;",
-                        ""
+                        "border-color: #7C3AED;"
                     ],
                     [
                         "rgb(109, 40, 217)",
                         "divide-purple-700",
-                        "border-color: #6D28D9;",
-                        ""
+                        "border-color: #6D28D9;"
                     ],
                     [
                         "rgb(91, 33, 182)",
                         "divide-purple-800",
-                        "border-color: #5B21B6;",
-                        ""
+                        "border-color: #5B21B6;"
                     ],
                     [
                         "rgb(76, 29, 149)",
                         "divide-purple-900",
-                        "border-color: #4C1D95;",
-                        ""
+                        "border-color: #4C1D95;"
                     ],
                     [
                         "rgb(253, 242, 248)",
                         "divide-pink-50",
-                        "border-color: #FDF2F8;",
-                        ""
+                        "border-color: #FDF2F8;"
                     ],
                     [
                         "rgb(252, 231, 243)",
                         "divide-pink-100",
-                        "border-color: #FCE7F3;",
-                        ""
+                        "border-color: #FCE7F3;"
                     ],
                     [
                         "rgb(251, 207, 232)",
                         "divide-pink-200",
-                        "border-color: #FBCFE8;",
-                        ""
+                        "border-color: #FBCFE8;"
                     ],
                     [
                         "rgb(249, 168, 212)",
                         "divide-pink-300",
-                        "border-color: #F9A8D4;",
-                        ""
+                        "border-color: #F9A8D4;"
                     ],
                     [
                         "rgb(244, 114, 182)",
                         "divide-pink-400",
-                        "border-color: #F472B6;",
-                        ""
+                        "border-color: #F472B6;"
                     ],
                     [
                         "rgb(236, 72, 153)",
                         "divide-pink-500",
-                        "border-color: #EC4899;",
-                        ""
+                        "border-color: #EC4899;"
                     ],
                     [
                         "rgb(219, 39, 119)",
                         "divide-pink-600",
-                        "border-color: #DB2777;",
-                        ""
+                        "border-color: #DB2777;"
                     ],
                     [
                         "rgb(190, 24, 93)",
                         "divide-pink-700",
-                        "border-color: #BE185D;",
-                        ""
+                        "border-color: #BE185D;"
                     ],
                     [
                         "rgb(157, 23, 77)",
                         "divide-pink-800",
-                        "border-color: #9D174D;",
-                        ""
+                        "border-color: #9D174D;"
                     ],
                     [
                         "rgb(131, 24, 67)",
                         "divide-pink-900",
-                        "border-color: #831843;",
-                        ""
+                        "border-color: #831843;"
                     ]
                 ]
             },
@@ -11576,73 +10247,59 @@
                 "table": [
                     [
                         "divide-opacity-0",
-                        "--divide-opacity: 0;",
-                        ""
+                        "--divide-opacity: 0;"
                     ],
                     [
                         "divide-opacity-5",
-                        "--divide-opacity: 0.05;",
-                        ""
+                        "--divide-opacity: 0.05;"
                     ],
                     [
                         "divide-opacity-10",
-                        "--divide-opacity: 0.1;",
-                        ""
+                        "--divide-opacity: 0.1;"
                     ],
                     [
                         "divide-opacity-20",
-                        "--divide-opacity: 0.2;",
-                        ""
+                        "--divide-opacity: 0.2;"
                     ],
                     [
                         "divide-opacity-25",
-                        "--divide-opacity: 0.25;",
-                        ""
+                        "--divide-opacity: 0.25;"
                     ],
                     [
                         "divide-opacity-30",
-                        "--divide-opacity: 0.3;",
-                        ""
+                        "--divide-opacity: 0.3;"
                     ],
                     [
                         "divide-opacity-40",
-                        "--divide-opacity: 0.4;",
-                        ""
+                        "--divide-opacity: 0.4;"
                     ],
                     [
                         "divide-opacity-50",
-                        "--divide-opacity: 0.5;",
-                        ""
+                        "--divide-opacity: 0.5;"
                     ],
                     [
                         "divide-opacity-60",
-                        "--divide-opacity: 0.6;",
-                        ""
+                        "--divide-opacity: 0.6;"
                     ],
                     [
                         "divide-opacity-70",
-                        "--divide-opacity: 0.7;",
-                        ""
+                        "--divide-opacity: 0.7;"
                     ],
                     [
                         "divide-opacity-75",
-                        "--divide-opacity: 0.75;",
-                        ""
+                        "--divide-opacity: 0.75;"
                     ],
                     [
                         "divide-opacity-80",
-                        "--divide-opacity: 0.8;",
-                        ""
+                        "--divide-opacity: 0.8;"
                     ],
                     [
                         "divide-opacity-90",
-                        "--divide-opacity: 0.9;",
-                        ""
+                        "--divide-opacity: 0.9;"
                     ],
                     [
                         "divide-opacity-100",
-                        "--divide-opacity: 1;",
-                        ""
+                        "--divide-opacity: 1;"
                     ]
                 ]
             },
@@ -11653,28 +10310,23 @@
                 "table": [
                     [
                         "divide-solid",
-                        "border-style: solid;",
-                        ""
+                        "border-style: solid;"
                     ],
                     [
                         "divide-dashed",
-                        "border-style: dashed;",
-                        ""
+                        "border-style: dashed;"
                     ],
                     [
                         "divide-dotted",
-                        "border-style: dotted;",
-                        ""
+                        "border-style: dotted;"
                     ],
                     [
                         "divide-double",
-                        "border-style: double;",
-                        ""
+                        "border-style: double;"
                     ],
                     [
                         "divide-none",
-                        "border-style: none;",
-                        ""
+                        "border-style: none;"
                     ]
                 ]
             },
@@ -11685,28 +10337,23 @@
                 "table": [
                     [
                         "outline-0",
-                        "outline-width: 0px;",
-                        ""
+                        "outline-width: 0px;"
                     ],
                     [
                         "outline-1",
-                        "outline-width: 1px;",
-                        ""
+                        "outline-width: 1px;"
                     ],
                     [
                         "outline-2",
-                        "outline-width: 2px;",
-                        ""
+                        "outline-width: 2px;"
                     ],
                     [
                         "outline-4",
-                        "outline-width: 4px;",
-                        ""
+                        "outline-width: 4px;"
                     ],
                     [
                         "outline-8",
-                        "outline-width: 8px;",
-                        ""
+                        "outline-width: 8px;"
                     ]
                 ]
             },
@@ -11717,33 +10364,27 @@
                 "table": [
                     [
                         "outline-solid",
-                        "outline-style: solid;",
-                        ""
+                        "outline-style: solid;"
                     ],
                     [
                         "outline-dashed",
-                        "outline-style: dashed;",
-                        ""
+                        "outline-style: dashed;"
                     ],
                     [
                         "outline-dotted",
-                        "outline-style: dotted;",
-                        ""
+                        "outline-style: dotted;"
                     ],
                     [
                         "outline-double",
-                        "outline-style: double;",
-                        ""
+                        "outline-style: double;"
                     ],
                     [
                         "outline-hidden",
-                        "outline-style: hidden;",
-                        ""
+                        "outline-style: hidden;"
                     ],
                     [
                         "outline-none",
-                        "outline-style: none;",
-                        ""
+                        "outline-style: none;"
                     ]
                 ]
             },
@@ -11754,28 +10395,23 @@
                 "table": [
                     [
                         "outline-offset-0",
-                        "outline-offset: 0px;",
-                        ""
+                        "outline-offset: 0px;"
                     ],
                     [
                         "outline-offset-1",
-                        "outline-offset: 1px;",
-                        ""
+                        "outline-offset: 1px;"
                     ],
                     [
                         "outline-offset-2",
-                        "outline-offset: 2px;",
-                        ""
+                        "outline-offset: 2px;"
                     ],
                     [
                         "outline-offset-4",
-                        "outline-offset: 4px;",
-                        ""
+                        "outline-offset: 4px;"
                     ],
                     [
                         "outline-offset-8",
-                        "outline-offset: 8px;",
-                        ""
+                        "outline-offset: 8px;"
                     ]
                 ]
             },
@@ -11786,38 +10422,31 @@
                 "table": [
                     [
                         "ring-0",
-                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);",
-                        ""
+                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);"
                     ],
                     [
                         "ring-1",
-                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);",
-                        ""
+                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);"
                     ],
                     [
                         "ring-2",
-                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);",
-                        ""
+                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);"
                     ],
                     [
                         "ring-4",
-                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);",
-                        ""
+                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);"
                     ],
                     [
                         "ring-8",
-                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);",
-                        ""
+                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);"
                     ],
                     [
                         "ring",
-                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);",
-                        ""
+                        "box-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);"
                     ],
                     [
                         "ring-inset",
-                        "--tw-ring-inset: inset;",
-                        ""
+                        "--tw-ring-inset: inset;"
                     ]
                 ]
             },
@@ -11829,506 +10458,422 @@
                     [
                         "transparent",
                         "ring-transparent",
-                        "--ring-color: transparent;",
-                        ""
+                        "--ring-color: transparent;"
                     ],
                     [
                         "current color",
                         "ring-current",
-                        "--ring-color: currentColor;",
-                        ""
+                        "--ring-color: currentColor;"
                     ],
                     [
                         "rgb(0, 0, 0)",
                         "ring-black",
-                        "--ring-color: #000000;",
-                        ""
+                        "--ring-color: #000000;"
                     ],
                     [
                         "rgb(255, 255, 255)",
                         "ring-white",
-                        "--ring-color: #ffffff;",
-                        ""
+                        "--ring-color: #ffffff;"
                     ],
                     [
                         "rgb(249, 250, 251)",
                         "ring-gray-50",
-                        "--ring-color: #F9FAFB;",
-                        ""
+                        "--ring-color: #F9FAFB;"
                     ],
                     [
                         "rgb(243, 244, 246)",
                         "ring-gray-100",
-                        "--ring-color: #F3F4F6;",
-                        ""
+                        "--ring-color: #F3F4F6;"
                     ],
                     [
                         "rgb(229, 231, 235)",
                         "ring-gray-200",
-                        "--ring-color: #E5E7EB;",
-                        ""
+                        "--ring-color: #E5E7EB;"
                     ],
                     [
                         "rgb(209, 213, 219)",
                         "ring-gray-300",
-                        "--ring-color: #D1D5DB;",
-                        ""
+                        "--ring-color: #D1D5DB;"
                     ],
                     [
                         "rgb(156, 163, 175)",
                         "ring-gray-400",
-                        "--ring-color: #9CA3AF;",
-                        ""
+                        "--ring-color: #9CA3AF;"
                     ],
                     [
                         "rgb(107, 114, 128)",
                         "ring-gray-500",
-                        "--ring-color: #6B7280;",
-                        ""
+                        "--ring-color: #6B7280;"
                     ],
                     [
                         "rgb(75, 85, 99)",
                         "ring-gray-600",
-                        "--ring-color: #4B5563;",
-                        ""
+                        "--ring-color: #4B5563;"
                     ],
                     [
                         "rgb(55, 65, 81)",
                         "ring-gray-700",
-                        "--ring-color: #374151;",
-                        ""
+                        "--ring-color: #374151;"
                     ],
                     [
                         "rgb(31, 41, 55)",
                         "ring-gray-800",
-                        "--ring-color: #1F2937;",
-                        ""
+                        "--ring-color: #1F2937;"
                     ],
                     [
                         "rgb(17, 24, 39)",
                         "ring-gray-900",
-                        "--ring-color: #111827;",
-                        ""
+                        "--ring-color: #111827;"
                     ],
                     [
                         "rgb(254, 242, 242)",
                         "ring-red-50",
-                        "--ring-color: #FEF2F2;",
-                        ""
+                        "--ring-color: #FEF2F2;"
                     ],
                     [
                         "rgb(254, 226, 226)",
                         "ring-red-100",
-                        "--ring-color: #FEE2E2;",
-                        ""
+                        "--ring-color: #FEE2E2;"
                     ],
                     [
                         "rgb(254, 202, 202)",
                         "ring-red-200",
-                        "--ring-color: #FECACA;",
-                        ""
+                        "--ring-color: #FECACA;"
                     ],
                     [
                         "rgb(252, 165, 165)",
                         "ring-red-300",
-                        "--ring-color: #FCA5A5;",
-                        ""
+                        "--ring-color: #FCA5A5;"
                     ],
                     [
                         "rgb(248, 113, 113)",
                         "ring-red-400",
-                        "--ring-color: #F87171;",
-                        ""
+                        "--ring-color: #F87171;"
                     ],
                     [
                         "rgb(239, 68, 68)",
                         "ring-red-500",
-                        "--ring-color: #EF4444;",
-                        ""
+                        "--ring-color: #EF4444;"
                     ],
                     [
                         "rgb(220, 38, 38)",
                         "ring-red-600",
-                        "--ring-color: #DC2626;",
-                        ""
+                        "--ring-color: #DC2626;"
                     ],
                     [
                         "rgb(185, 28, 28)",
                         "ring-red-700",
-                        "--ring-color: #B91C1C;",
-                        ""
+                        "--ring-color: #B91C1C;"
                     ],
                     [
                         "rgb(153, 27, 27)",
                         "ring-red-800",
-                        "--ring-color: #991B1B;",
-                        ""
+                        "--ring-color: #991B1B;"
                     ],
                     [
                         "rgb(127, 29, 29)",
                         "ring-red-900",
-                        "--ring-color: #7F1D1D;",
-                        ""
+                        "--ring-color: #7F1D1D;"
                     ],
                     [
                         "rgb(255, 251, 235)",
                         "ring-yellow-50",
-                        "--ring-color: #FFFBEB;",
-                        ""
+                        "--ring-color: #FFFBEB;"
                     ],
                     [
                         "rgb(254, 243, 199)",
                         "ring-yellow-100",
-                        "--ring-color: #FEF3C7;",
-                        ""
+                        "--ring-color: #FEF3C7;"
                     ],
                     [
                         "rgb(253, 230, 138)",
                         "ring-yellow-200",
-                        "--ring-color: #FDE68A;",
-                        ""
+                        "--ring-color: #FDE68A;"
                     ],
                     [
                         "rgb(252, 211, 77)",
                         "ring-yellow-300",
-                        "--ring-color: #FCD34D;",
-                        ""
+                        "--ring-color: #FCD34D;"
                     ],
                     [
                         "rgb(251, 191, 36)",
                         "ring-yellow-400",
-                        "--ring-color: #FBBF24;",
-                        ""
+                        "--ring-color: #FBBF24;"
                     ],
                     [
                         "rgb(245, 158, 11)",
                         "ring-yellow-500",
-                        "--ring-color: #F59E0B;",
-                        ""
+                        "--ring-color: #F59E0B;"
                     ],
                     [
                         "rgb(217, 119, 6)",
                         "ring-yellow-600",
-                        "--ring-color: #D97706;",
-                        ""
+                        "--ring-color: #D97706;"
                     ],
                     [
                         "rgb(180, 83, 9)",
                         "ring-yellow-700",
-                        "--ring-color: #B45309;",
-                        ""
+                        "--ring-color: #B45309;"
                     ],
                     [
                         "rgb(146, 64, 14)",
                         "ring-yellow-800",
-                        "--ring-color: #92400E;",
-                        ""
+                        "--ring-color: #92400E;"
                     ],
                     [
                         "rgb(120, 53, 15)",
                         "ring-yellow-900",
-                        "--ring-color: #78350F;",
-                        ""
+                        "--ring-color: #78350F;"
                     ],
                     [
                         "rgb(236, 253, 245)",
                         "ring-green-50",
-                        "--ring-color: #ECFDF5;",
-                        ""
+                        "--ring-color: #ECFDF5;"
                     ],
                     [
                         "rgb(209, 250, 229)",
                         "ring-green-100",
-                        "--ring-color: #D1FAE5;",
-                        ""
+                        "--ring-color: #D1FAE5;"
                     ],
                     [
                         "rgb(167, 243, 208)",
                         "ring-green-200",
-                        "--ring-color: #A7F3D0;",
-                        ""
+                        "--ring-color: #A7F3D0;"
                     ],
                     [
                         "rgb(110, 231, 183)",
                         "ring-green-300",
-                        "--ring-color: #6EE7B7;",
-                        ""
+                        "--ring-color: #6EE7B7;"
                     ],
                     [
                         "rgb(52, 211, 153)",
                         "ring-green-400",
-                        "--ring-color: #34D399;",
-                        ""
+                        "--ring-color: #34D399;"
                     ],
                     [
                         "rgb(16, 185, 129)",
                         "ring-green-500",
-                        "--ring-color: #10B981;",
-                        ""
+                        "--ring-color: #10B981;"
                     ],
                     [
                         "rgb(5, 150, 105)",
                         "ring-green-600",
-                        "--ring-color: #059669;",
-                        ""
+                        "--ring-color: #059669;"
                     ],
                     [
                         "rgb(4, 120, 87)",
                         "ring-green-700",
-                        "--ring-color: #047857;",
-                        ""
+                        "--ring-color: #047857;"
                     ],
                     [
                         "rgb(6, 95, 70)",
                         "ring-green-800",
-                        "--ring-color: #065F46;",
-                        ""
+                        "--ring-color: #065F46;"
                     ],
                     [
                         "rgb(6, 78, 59)",
                         "ring-green-900",
-                        "--ring-color: #064E3B;",
-                        ""
+                        "--ring-color: #064E3B;"
                     ],
                     [
                         "rgb(239, 246, 255)",
                         "ring-blue-50",
-                        "--ring-color: #EFF6FF;",
-                        ""
+                        "--ring-color: #EFF6FF;"
                     ],
                     [
                         "rgb(219, 234, 254)",
                         "ring-blue-100",
-                        "--ring-color: #DBEAFE;",
-                        ""
+                        "--ring-color: #DBEAFE;"
                     ],
                     [
                         "rgb(191, 219, 254)",
                         "ring-blue-200",
-                        "--ring-color: #BFDBFE;",
-                        ""
+                        "--ring-color: #BFDBFE;"
                     ],
                     [
                         "rgb(147, 197, 253)",
                         "ring-blue-300",
-                        "--ring-color: #93C5FD;",
-                        ""
+                        "--ring-color: #93C5FD;"
                     ],
                     [
                         "rgb(96, 165, 250)",
                         "ring-blue-400",
-                        "--ring-color: #60A5FA;",
-                        ""
+                        "--ring-color: #60A5FA;"
                     ],
                     [
                         "rgb(59, 130, 246)",
                         "ring-blue-500",
-                        "--ring-color: #3B82F6;",
-                        ""
+                        "--ring-color: #3B82F6;"
                     ],
                     [
                         "rgb(37, 99, 235)",
                         "ring-blue-600",
-                        "--ring-color: #2563EB;",
-                        ""
+                        "--ring-color: #2563EB;"
                     ],
                     [
                         "rgb(29, 78, 216)",
                         "ring-blue-700",
-                        "--ring-color: #1D4ED8;",
-                        ""
+                        "--ring-color: #1D4ED8;"
                     ],
                     [
                         "rgb(30, 64, 175)",
                         "ring-blue-800",
-                        "--ring-color: #1E40AF;",
-                        ""
+                        "--ring-color: #1E40AF;"
                     ],
                     [
                         "rgb(30, 58, 138)",
                         "ring-blue-900",
-                        "--ring-color: #1E3A8A;",
-                        ""
+                        "--ring-color: #1E3A8A;"
                     ],
                     [
                         "rgb(238, 242, 255)",
                         "ring-indigo-50",
-                        "--ring-color: #EEF2FF;",
-                        ""
+                        "--ring-color: #EEF2FF;"
                     ],
                     [
                         "rgb(224, 231, 255)",
                         "ring-indigo-100",
-                        "--ring-color: #E0E7FF;",
-                        ""
+                        "--ring-color: #E0E7FF;"
                     ],
                     [
                         "rgb(199, 210, 254)",
                         "ring-indigo-200",
-                        "--ring-color: #C7D2FE;",
-                        ""
+                        "--ring-color: #C7D2FE;"
                     ],
                     [
                         "rgb(165, 180, 252)",
                         "ring-indigo-300",
-                        "--ring-color: #A5B4FC;",
-                        ""
+                        "--ring-color: #A5B4FC;"
                     ],
                     [
                         "rgb(129, 140, 248)",
                         "ring-indigo-400",
-                        "--ring-color: #818CF8;",
-                        ""
+                        "--ring-color: #818CF8;"
                     ],
                     [
                         "rgb(99, 102, 241)",
                         "ring-indigo-500",
-                        "--ring-color: #6366F1;",
-                        ""
+                        "--ring-color: #6366F1;"
                     ],
                     [
                         "rgb(79, 70, 229)",
                         "ring-indigo-600",
-                        "--ring-color: #4F46E5;",
-                        ""
+                        "--ring-color: #4F46E5;"
                     ],
                     [
                         "rgb(67, 56, 202)",
                         "ring-indigo-700",
-                        "--ring-color: #4338CA;",
-                        ""
+                        "--ring-color: #4338CA;"
                     ],
                     [
                         "rgb(55, 48, 163)",
                         "ring-indigo-800",
-                        "--ring-color: #3730A3;",
-                        ""
+                        "--ring-color: #3730A3;"
                     ],
                     [
                         "rgb(49, 46, 129)",
                         "ring-indigo-900",
-                        "--ring-color: #312E81;",
-                        ""
+                        "--ring-color: #312E81;"
                     ],
                     [
                         "rgb(245, 243, 255)",
                         "ring-purple-50",
-                        "--ring-color: #F5F3FF;",
-                        ""
+                        "--ring-color: #F5F3FF;"
                     ],
                     [
                         "rgb(237, 233, 254)",
                         "ring-purple-100",
-                        "--ring-color: #EDE9FE;",
-                        ""
+                        "--ring-color: #EDE9FE;"
                     ],
                     [
                         "rgb(221, 214, 254)",
                         "ring-purple-200",
-                        "--ring-color: #DDD6FE;",
-                        ""
+                        "--ring-color: #DDD6FE;"
                     ],
                     [
                         "rgb(196, 181, 253)",
                         "ring-purple-300",
-                        "--ring-color: #C4B5FD;",
-                        ""
+                        "--ring-color: #C4B5FD;"
                     ],
                     [
                         "rgb(167, 139, 250)",
                         "ring-purple-400",
-                        "--ring-color: #A78BFA;",
-                        ""
+                        "--ring-color: #A78BFA;"
                     ],
                     [
                         "rgb(139, 92, 246)",
                         "ring-purple-500",
-                        "--ring-color: #8B5CF6;",
-                        ""
+                        "--ring-color: #8B5CF6;"
                     ],
                     [
                         "rgb(124, 58, 237)",
                         "ring-purple-600",
-                        "--ring-color: #7C3AED;",
-                        ""
+                        "--ring-color: #7C3AED;"
                     ],
                     [
                         "rgb(109, 40, 217)",
                         "ring-purple-700",
-                        "--ring-color: #6D28D9;",
-                        ""
+                        "--ring-color: #6D28D9;"
                     ],
                     [
                         "rgb(91, 33, 182)",
                         "ring-purple-800",
-                        "--ring-color: #5B21B6;",
-                        ""
+                        "--ring-color: #5B21B6;"
                     ],
                     [
                         "rgb(76, 29, 149)",
                         "ring-purple-900",
-                        "--ring-color: #4C1D95;",
-                        ""
+                        "--ring-color: #4C1D95;"
                     ],
                     [
                         "rgb(253, 242, 248)",
                         "ring-pink-50",
-                        "--ring-color: #FDF2F8;",
-                        ""
+                        "--ring-color: #FDF2F8;"
                     ],
                     [
                         "rgb(252, 231, 243)",
                         "ring-pink-100",
-                        "--ring-color: #FCE7F3;",
-                        ""
+                        "--ring-color: #FCE7F3;"
                     ],
                     [
                         "rgb(251, 207, 232)",
                         "ring-pink-200",
-                        "--ring-color: #FBCFE8;",
-                        ""
+                        "--ring-color: #FBCFE8;"
                     ],
                     [
                         "rgb(249, 168, 212)",
                         "ring-pink-300",
-                        "--ring-color: #F9A8D4;",
-                        ""
+                        "--ring-color: #F9A8D4;"
                     ],
                     [
                         "rgb(244, 114, 182)",
                         "ring-pink-400",
-                        "--ring-color: #F472B6;",
-                        ""
+                        "--ring-color: #F472B6;"
                     ],
                     [
                         "rgb(236, 72, 153)",
                         "ring-pink-500",
-                        "--ring-color: #EC4899;",
-                        ""
+                        "--ring-color: #EC4899;"
                     ],
                     [
                         "rgb(219, 39, 119)",
                         "ring-pink-600",
-                        "--ring-color: #DB2777;",
-                        ""
+                        "--ring-color: #DB2777;"
                     ],
                     [
                         "rgb(190, 24, 93)",
                         "ring-pink-700",
-                        "--ring-color: #BE185D;",
-                        ""
+                        "--ring-color: #BE185D;"
                     ],
                     [
                         "rgb(157, 23, 77)",
                         "ring-pink-800",
-                        "--ring-color: #9D174D;",
-                        ""
+                        "--ring-color: #9D174D;"
                     ],
                     [
                         "rgb(131, 24, 67)",
                         "ring-pink-900",
-                        "--ring-color: #831843;",
-                        ""
+                        "--ring-color: #831843;"
                     ]
                 ]
             },
@@ -12339,73 +10884,59 @@
                 "table": [
                     [
                         "ring-opacity-0",
-                        "--ring-opacity: 0;",
-                        ""
+                        "--ring-opacity: 0;"
                     ],
                     [
                         "ring-opacity-5",
-                        "--ring-opacity: 0.05;",
-                        ""
+                        "--ring-opacity: 0.05;"
                     ],
                     [
                         "ring-opacity-10",
-                        "--ring-opacity: 0.1;",
-                        ""
+                        "--ring-opacity: 0.1;"
                     ],
                     [
                         "ring-opacity-20",
-                        "--ring-opacity: 0.2;",
-                        ""
+                        "--ring-opacity: 0.2;"
                     ],
                     [
                         "ring-opacity-25",
-                        "--ring-opacity: 0.25;",
-                        ""
+                        "--ring-opacity: 0.25;"
                     ],
                     [
                         "ring-opacity-30",
-                        "--ring-opacity: 0.3;",
-                        ""
+                        "--ring-opacity: 0.3;"
                     ],
                     [
                         "ring-opacity-40",
-                        "--ring-opacity: 0.4;",
-                        ""
+                        "--ring-opacity: 0.4;"
                     ],
                     [
                         "ring-opacity-50",
-                        "--ring-opacity: 0.5;",
-                        ""
+                        "--ring-opacity: 0.5;"
                     ],
                     [
                         "ring-opacity-60",
-                        "--ring-opacity: 0.6;",
-                        ""
+                        "--ring-opacity: 0.6;"
                     ],
                     [
                         "ring-opacity-70",
-                        "--ring-opacity: 0.7;",
-                        ""
+                        "--ring-opacity: 0.7;"
                     ],
                     [
                         "ring-opacity-75",
-                        "--ring-opacity: 0.75;",
-                        ""
+                        "--ring-opacity: 0.75;"
                     ],
                     [
                         "ring-opacity-80",
-                        "--ring-opacity: 0.8;",
-                        ""
+                        "--ring-opacity: 0.8;"
                     ],
                     [
                         "ring-opacity-90",
-                        "--ring-opacity: 0.9;",
-                        ""
+                        "--ring-opacity: 0.9;"
                     ],
                     [
                         "ring-opacity-100",
-                        "--ring-opacity: 1;",
-                        ""
+                        "--ring-opacity: 1;"
                     ]
                 ]
             },
@@ -12416,28 +10947,23 @@
                 "table": [
                     [
                         "ring-offset-0",
-                        "--ring-offset-width: 0px;\nbox-shadow: 0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow);",
-                        ""
+                        "--ring-offset-width: 0px;\nbox-shadow: 0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow);"
                     ],
                     [
                         "ring-offset-1",
-                        "--ring-offset-width: 1px;\nbox-shadow: 0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow);",
-                        ""
+                        "--ring-offset-width: 1px;\nbox-shadow: 0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow);"
                     ],
                     [
                         "ring-offset-2",
-                        "--ring-offset-width: 2px;\nbox-shadow: 0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow);",
-                        ""
+                        "--ring-offset-width: 2px;\nbox-shadow: 0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow);"
                     ],
                     [
                         "ring-offset-4",
-                        "--ring-offset-width: 4px;\nbox-shadow: 0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow);",
-                        ""
+                        "--ring-offset-width: 4px;\nbox-shadow: 0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow);"
                     ],
                     [
                         "ring-offset-8",
-                        "--ring-offset-width: 8px;\nbox-shadow: 0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow);",
-                        ""
+                        "--ring-offset-width: 8px;\nbox-shadow: 0 0 0 var(--ring-offset-width) var(--ring-offset-color), var(--ring-shadow);"
                     ]
                 ]
             },
@@ -12449,506 +10975,422 @@
                     [
                         "transparent",
                         "ring-offset-transparent",
-                        "--ring-offset-color: transparent;",
-                        ""
+                        "--ring-offset-color: transparent;"
                     ],
                     [
                         "current color",
                         "ring-offset-current",
-                        "--ring-offset-color: currentColor;",
-                        ""
+                        "--ring-offset-color: currentColor;"
                     ],
                     [
                         "rgb(0, 0, 0)",
                         "ring-offset-black",
-                        "--ring-offset-color: #000000;",
-                        ""
+                        "--ring-offset-color: #000000;"
                     ],
                     [
                         "rgb(255, 255, 255)",
                         "ring-offset-white",
-                        "--ring-offset-color: #ffffff;",
-                        ""
+                        "--ring-offset-color: #ffffff;"
                     ],
                     [
                         "rgb(249, 250, 251)",
                         "ring-offset-gray-50",
-                        "--ring-offset-color: #F9FAFB;",
-                        ""
+                        "--ring-offset-color: #F9FAFB;"
                     ],
                     [
                         "rgb(243, 244, 246)",
                         "ring-offset-gray-100",
-                        "--ring-offset-color: #F3F4F6;",
-                        ""
+                        "--ring-offset-color: #F3F4F6;"
                     ],
                     [
                         "rgb(229, 231, 235)",
                         "ring-offset-gray-200",
-                        "--ring-offset-color: #E5E7EB;",
-                        ""
+                        "--ring-offset-color: #E5E7EB;"
                     ],
                     [
                         "rgb(209, 213, 219)",
                         "ring-offset-gray-300",
-                        "--ring-offset-color: #D1D5DB;",
-                        ""
+                        "--ring-offset-color: #D1D5DB;"
                     ],
                     [
                         "rgb(156, 163, 175)",
                         "ring-offset-gray-400",
-                        "--ring-offset-color: #9CA3AF;",
-                        ""
+                        "--ring-offset-color: #9CA3AF;"
                     ],
                     [
                         "rgb(107, 114, 128)",
                         "ring-offset-gray-500",
-                        "--ring-offset-color: #6B7280;",
-                        ""
+                        "--ring-offset-color: #6B7280;"
                     ],
                     [
                         "rgb(75, 85, 99)",
                         "ring-offset-gray-600",
-                        "--ring-offset-color: #4B5563;",
-                        ""
+                        "--ring-offset-color: #4B5563;"
                     ],
                     [
                         "rgb(55, 65, 81)",
                         "ring-offset-gray-700",
-                        "--ring-offset-color: #374151;",
-                        ""
+                        "--ring-offset-color: #374151;"
                     ],
                     [
                         "rgb(31, 41, 55)",
                         "ring-offset-gray-800",
-                        "--ring-offset-color: #1F2937;",
-                        ""
+                        "--ring-offset-color: #1F2937;"
                     ],
                     [
                         "rgb(17, 24, 39)",
                         "ring-offset-gray-900",
-                        "--ring-offset-color: #111827;",
-                        ""
+                        "--ring-offset-color: #111827;"
                     ],
                     [
                         "rgb(254, 242, 242)",
                         "ring-offset-red-50",
-                        "--ring-offset-color: #FEF2F2;",
-                        ""
+                        "--ring-offset-color: #FEF2F2;"
                     ],
                     [
                         "rgb(254, 226, 226)",
                         "ring-offset-red-100",
-                        "--ring-offset-color: #FEE2E2;",
-                        ""
+                        "--ring-offset-color: #FEE2E2;"
                     ],
                     [
                         "rgb(254, 202, 202)",
                         "ring-offset-red-200",
-                        "--ring-offset-color: #FECACA;",
-                        ""
+                        "--ring-offset-color: #FECACA;"
                     ],
                     [
                         "rgb(252, 165, 165)",
                         "ring-offset-red-300",
-                        "--ring-offset-color: #FCA5A5;",
-                        ""
+                        "--ring-offset-color: #FCA5A5;"
                     ],
                     [
                         "rgb(248, 113, 113)",
                         "ring-offset-red-400",
-                        "--ring-offset-color: #F87171;",
-                        ""
+                        "--ring-offset-color: #F87171;"
                     ],
                     [
                         "rgb(239, 68, 68)",
                         "ring-offset-red-500",
-                        "--ring-offset-color: #EF4444;",
-                        ""
+                        "--ring-offset-color: #EF4444;"
                     ],
                     [
                         "rgb(220, 38, 38)",
                         "ring-offset-red-600",
-                        "--ring-offset-color: #DC2626;",
-                        ""
+                        "--ring-offset-color: #DC2626;"
                     ],
                     [
                         "rgb(185, 28, 28)",
                         "ring-offset-red-700",
-                        "--ring-offset-color: #B91C1C;",
-                        ""
+                        "--ring-offset-color: #B91C1C;"
                     ],
                     [
                         "rgb(153, 27, 27)",
                         "ring-offset-red-800",
-                        "--ring-offset-color: #991B1B;",
-                        ""
+                        "--ring-offset-color: #991B1B;"
                     ],
                     [
                         "rgb(127, 29, 29)",
                         "ring-offset-red-900",
-                        "--ring-offset-color: #7F1D1D;",
-                        ""
+                        "--ring-offset-color: #7F1D1D;"
                     ],
                     [
                         "rgb(255, 251, 235)",
                         "ring-offset-yellow-50",
-                        "--ring-offset-color: #FFFBEB;",
-                        ""
+                        "--ring-offset-color: #FFFBEB;"
                     ],
                     [
                         "rgb(254, 243, 199)",
                         "ring-offset-yellow-100",
-                        "--ring-offset-color: #FEF3C7;",
-                        ""
+                        "--ring-offset-color: #FEF3C7;"
                     ],
                     [
                         "rgb(253, 230, 138)",
                         "ring-offset-yellow-200",
-                        "--ring-offset-color: #FDE68A;",
-                        ""
+                        "--ring-offset-color: #FDE68A;"
                     ],
                     [
                         "rgb(252, 211, 77)",
                         "ring-offset-yellow-300",
-                        "--ring-offset-color: #FCD34D;",
-                        ""
+                        "--ring-offset-color: #FCD34D;"
                     ],
                     [
                         "rgb(251, 191, 36)",
                         "ring-offset-yellow-400",
-                        "--ring-offset-color: #FBBF24;",
-                        ""
+                        "--ring-offset-color: #FBBF24;"
                     ],
                     [
                         "rgb(245, 158, 11)",
                         "ring-offset-yellow-500",
-                        "--ring-offset-color: #F59E0B;",
-                        ""
+                        "--ring-offset-color: #F59E0B;"
                     ],
                     [
                         "rgb(217, 119, 6)",
                         "ring-offset-yellow-600",
-                        "--ring-offset-color: #D97706;",
-                        ""
+                        "--ring-offset-color: #D97706;"
                     ],
                     [
                         "rgb(180, 83, 9)",
                         "ring-offset-yellow-700",
-                        "--ring-offset-color: #B45309;",
-                        ""
+                        "--ring-offset-color: #B45309;"
                     ],
                     [
                         "rgb(146, 64, 14)",
                         "ring-offset-yellow-800",
-                        "--ring-offset-color: #92400E;",
-                        ""
+                        "--ring-offset-color: #92400E;"
                     ],
                     [
                         "rgb(120, 53, 15)",
                         "ring-offset-yellow-900",
-                        "--ring-offset-color: #78350F;",
-                        ""
+                        "--ring-offset-color: #78350F;"
                     ],
                     [
                         "rgb(236, 253, 245)",
                         "ring-offset-green-50",
-                        "--ring-offset-color: #ECFDF5;",
-                        ""
+                        "--ring-offset-color: #ECFDF5;"
                     ],
                     [
                         "rgb(209, 250, 229)",
                         "ring-offset-green-100",
-                        "--ring-offset-color: #D1FAE5;",
-                        ""
+                        "--ring-offset-color: #D1FAE5;"
                     ],
                     [
                         "rgb(167, 243, 208)",
                         "ring-offset-green-200",
-                        "--ring-offset-color: #A7F3D0;",
-                        ""
+                        "--ring-offset-color: #A7F3D0;"
                     ],
                     [
                         "rgb(110, 231, 183)",
                         "ring-offset-green-300",
-                        "--ring-offset-color: #6EE7B7;",
-                        ""
+                        "--ring-offset-color: #6EE7B7;"
                     ],
                     [
                         "rgb(52, 211, 153)",
                         "ring-offset-green-400",
-                        "--ring-offset-color: #34D399;",
-                        ""
+                        "--ring-offset-color: #34D399;"
                     ],
                     [
                         "rgb(16, 185, 129)",
                         "ring-offset-green-500",
-                        "--ring-offset-color: #10B981;",
-                        ""
+                        "--ring-offset-color: #10B981;"
                     ],
                     [
                         "rgb(5, 150, 105)",
                         "ring-offset-green-600",
-                        "--ring-offset-color: #059669;",
-                        ""
+                        "--ring-offset-color: #059669;"
                     ],
                     [
                         "rgb(4, 120, 87)",
                         "ring-offset-green-700",
-                        "--ring-offset-color: #047857;",
-                        ""
+                        "--ring-offset-color: #047857;"
                     ],
                     [
                         "rgb(6, 95, 70)",
                         "ring-offset-green-800",
-                        "--ring-offset-color: #065F46;",
-                        ""
+                        "--ring-offset-color: #065F46;"
                     ],
                     [
                         "rgb(6, 78, 59)",
                         "ring-offset-green-900",
-                        "--ring-offset-color: #064E3B;",
-                        ""
+                        "--ring-offset-color: #064E3B;"
                     ],
                     [
                         "rgb(239, 246, 255)",
                         "ring-offset-blue-50",
-                        "--ring-offset-color: #EFF6FF;",
-                        ""
+                        "--ring-offset-color: #EFF6FF;"
                     ],
                     [
                         "rgb(219, 234, 254)",
                         "ring-offset-blue-100",
-                        "--ring-offset-color: #DBEAFE;",
-                        ""
+                        "--ring-offset-color: #DBEAFE;"
                     ],
                     [
                         "rgb(191, 219, 254)",
                         "ring-offset-blue-200",
-                        "--ring-offset-color: #BFDBFE;",
-                        ""
+                        "--ring-offset-color: #BFDBFE;"
                     ],
                     [
                         "rgb(147, 197, 253)",
                         "ring-offset-blue-300",
-                        "--ring-offset-color: #93C5FD;",
-                        ""
+                        "--ring-offset-color: #93C5FD;"
                     ],
                     [
                         "rgb(96, 165, 250)",
                         "ring-offset-blue-400",
-                        "--ring-offset-color: #60A5FA;",
-                        ""
+                        "--ring-offset-color: #60A5FA;"
                     ],
                     [
                         "rgb(59, 130, 246)",
                         "ring-offset-blue-500",
-                        "--ring-offset-color: #3B82F6;",
-                        ""
+                        "--ring-offset-color: #3B82F6;"
                     ],
                     [
                         "rgb(37, 99, 235)",
                         "ring-offset-blue-600",
-                        "--ring-offset-color: #2563EB;",
-                        ""
+                        "--ring-offset-color: #2563EB;"
                     ],
                     [
                         "rgb(29, 78, 216)",
                         "ring-offset-blue-700",
-                        "--ring-offset-color: #1D4ED8;",
-                        ""
+                        "--ring-offset-color: #1D4ED8;"
                     ],
                     [
                         "rgb(30, 64, 175)",
                         "ring-offset-blue-800",
-                        "--ring-offset-color: #1E40AF;",
-                        ""
+                        "--ring-offset-color: #1E40AF;"
                     ],
                     [
                         "rgb(30, 58, 138)",
                         "ring-offset-blue-900",
-                        "--ring-offset-color: #1E3A8A;",
-                        ""
+                        "--ring-offset-color: #1E3A8A;"
                     ],
                     [
                         "rgb(238, 242, 255)",
                         "ring-offset-indigo-50",
-                        "--ring-offset-color: #EEF2FF;",
-                        ""
+                        "--ring-offset-color: #EEF2FF;"
                     ],
                     [
                         "rgb(224, 231, 255)",
                         "ring-offset-indigo-100",
-                        "--ring-offset-color: #E0E7FF;",
-                        ""
+                        "--ring-offset-color: #E0E7FF;"
                     ],
                     [
                         "rgb(199, 210, 254)",
                         "ring-offset-indigo-200",
-                        "--ring-offset-color: #C7D2FE;",
-                        ""
+                        "--ring-offset-color: #C7D2FE;"
                     ],
                     [
                         "rgb(165, 180, 252)",
                         "ring-offset-indigo-300",
-                        "--ring-offset-color: #A5B4FC;",
-                        ""
+                        "--ring-offset-color: #A5B4FC;"
                     ],
                     [
                         "rgb(129, 140, 248)",
                         "ring-offset-indigo-400",
-                        "--ring-offset-color: #818CF8;",
-                        ""
+                        "--ring-offset-color: #818CF8;"
                     ],
                     [
                         "rgb(99, 102, 241)",
                         "ring-offset-indigo-500",
-                        "--ring-offset-color: #6366F1;",
-                        ""
+                        "--ring-offset-color: #6366F1;"
                     ],
                     [
                         "rgb(79, 70, 229)",
                         "ring-offset-indigo-600",
-                        "--ring-offset-color: #4F46E5;",
-                        ""
+                        "--ring-offset-color: #4F46E5;"
                     ],
                     [
                         "rgb(67, 56, 202)",
                         "ring-offset-indigo-700",
-                        "--ring-offset-color: #4338CA;",
-                        ""
+                        "--ring-offset-color: #4338CA;"
                     ],
                     [
                         "rgb(55, 48, 163)",
                         "ring-offset-indigo-800",
-                        "--ring-offset-color: #3730A3;",
-                        ""
+                        "--ring-offset-color: #3730A3;"
                     ],
                     [
                         "rgb(49, 46, 129)",
                         "ring-offset-indigo-900",
-                        "--ring-offset-color: #312E81;",
-                        ""
+                        "--ring-offset-color: #312E81;"
                     ],
                     [
                         "rgb(245, 243, 255)",
                         "ring-offset-purple-50",
-                        "--ring-offset-color: #F5F3FF;",
-                        ""
+                        "--ring-offset-color: #F5F3FF;"
                     ],
                     [
                         "rgb(237, 233, 254)",
                         "ring-offset-purple-100",
-                        "--ring-offset-color: #EDE9FE;",
-                        ""
+                        "--ring-offset-color: #EDE9FE;"
                     ],
                     [
                         "rgb(221, 214, 254)",
                         "ring-offset-purple-200",
-                        "--ring-offset-color: #DDD6FE;",
-                        ""
+                        "--ring-offset-color: #DDD6FE;"
                     ],
                     [
                         "rgb(196, 181, 253)",
                         "ring-offset-purple-300",
-                        "--ring-offset-color: #C4B5FD;",
-                        ""
+                        "--ring-offset-color: #C4B5FD;"
                     ],
                     [
                         "rgb(167, 139, 250)",
                         "ring-offset-purple-400",
-                        "--ring-offset-color: #A78BFA;",
-                        ""
+                        "--ring-offset-color: #A78BFA;"
                     ],
                     [
                         "rgb(139, 92, 246)",
                         "ring-offset-purple-500",
-                        "--ring-offset-color: #8B5CF6;",
-                        ""
+                        "--ring-offset-color: #8B5CF6;"
                     ],
                     [
                         "rgb(124, 58, 237)",
                         "ring-offset-purple-600",
-                        "--ring-offset-color: #7C3AED;",
-                        ""
+                        "--ring-offset-color: #7C3AED;"
                     ],
                     [
                         "rgb(109, 40, 217)",
                         "ring-offset-purple-700",
-                        "--ring-offset-color: #6D28D9;",
-                        ""
+                        "--ring-offset-color: #6D28D9;"
                     ],
                     [
                         "rgb(91, 33, 182)",
                         "ring-offset-purple-800",
-                        "--ring-offset-color: #5B21B6;",
-                        ""
+                        "--ring-offset-color: #5B21B6;"
                     ],
                     [
                         "rgb(76, 29, 149)",
                         "ring-offset-purple-900",
-                        "--ring-offset-color: #4C1D95;",
-                        ""
+                        "--ring-offset-color: #4C1D95;"
                     ],
                     [
                         "rgb(253, 242, 248)",
                         "ring-offset-pink-50",
-                        "--ring-offset-color: #FDF2F8;",
-                        ""
+                        "--ring-offset-color: #FDF2F8;"
                     ],
                     [
                         "rgb(252, 231, 243)",
                         "ring-offset-pink-100",
-                        "--ring-offset-color: #FCE7F3;",
-                        ""
+                        "--ring-offset-color: #FCE7F3;"
                     ],
                     [
                         "rgb(251, 207, 232)",
                         "ring-offset-pink-200",
-                        "--ring-offset-color: #FBCFE8;",
-                        ""
+                        "--ring-offset-color: #FBCFE8;"
                     ],
                     [
                         "rgb(249, 168, 212)",
                         "ring-offset-pink-300",
-                        "--ring-offset-color: #F9A8D4;",
-                        ""
+                        "--ring-offset-color: #F9A8D4;"
                     ],
                     [
                         "rgb(244, 114, 182)",
                         "ring-offset-pink-400",
-                        "--ring-offset-color: #F472B6;",
-                        ""
+                        "--ring-offset-color: #F472B6;"
                     ],
                     [
                         "rgb(236, 72, 153)",
                         "ring-offset-pink-500",
-                        "--ring-offset-color: #EC4899;",
-                        ""
+                        "--ring-offset-color: #EC4899;"
                     ],
                     [
                         "rgb(219, 39, 119)",
                         "ring-offset-pink-600",
-                        "--ring-offset-color: #DB2777;",
-                        ""
+                        "--ring-offset-color: #DB2777;"
                     ],
                     [
                         "rgb(190, 24, 93)",
                         "ring-offset-pink-700",
-                        "--ring-offset-color: #BE185D;",
-                        ""
+                        "--ring-offset-color: #BE185D;"
                     ],
                     [
                         "rgb(157, 23, 77)",
                         "ring-offset-pink-800",
-                        "--ring-offset-color: #9D174D;",
-                        ""
+                        "--ring-offset-color: #9D174D;"
                     ],
                     [
                         "rgb(131, 24, 67)",
                         "ring-offset-pink-900",
-                        "--ring-offset-color: #831843;",
-                        ""
+                        "--ring-offset-color: #831843;"
                     ]
                 ]
             }
@@ -12964,8 +11406,7 @@
                 "table": [
                     [
                         "w-0",
-                        "width: 0;",
-                        ""
+                        "width: 0;"
                     ],
                     [
                         "w-0.5",
@@ -13119,168 +11560,135 @@
                     ],
                     [
                         "w-px",
-                        "width: 1px;",
-                        ""
+                        "width: 1px;"
                     ],
                     [
                         "w-auto",
-                        "width: auto;",
-                        ""
+                        "width: auto;"
                     ],
                     [
                         "w-1/2",
-                        "width: 50%;",
-                        ""
+                        "width: 50%;"
                     ],
                     [
                         "w-1/3",
-                        "width: 33.333333%;",
-                        ""
+                        "width: 33.333333%;"
                     ],
                     [
                         "w-2/3",
-                        "width: 66.666667%;",
-                        ""
+                        "width: 66.666667%;"
                     ],
                     [
                         "w-1/4",
-                        "width: 25%;",
-                        ""
+                        "width: 25%;"
                     ],
                     [
                         "w-2/4",
-                        "width: 50%;",
-                        ""
+                        "width: 50%;"
                     ],
                     [
                         "w-3/4",
-                        "width: 75%;",
-                        ""
+                        "width: 75%;"
                     ],
                     [
                         "w-1/5",
-                        "width: 20%;",
-                        ""
+                        "width: 20%;"
                     ],
                     [
                         "w-2/5",
-                        "width: 40%;",
-                        ""
+                        "width: 40%;"
                     ],
                     [
                         "w-3/5",
-                        "width: 60%;",
-                        ""
+                        "width: 60%;"
                     ],
                     [
                         "w-4/5",
-                        "width: 80%;",
-                        ""
+                        "width: 80%;"
                     ],
                     [
                         "w-1/6",
-                        "width: 16.666667%;",
-                        ""
+                        "width: 16.666667%;"
                     ],
                     [
                         "w-2/6",
-                        "width: 33.333333%;",
-                        ""
+                        "width: 33.333333%;"
                     ],
                     [
                         "w-3/6",
-                        "width: 50%;",
-                        ""
+                        "width: 50%;"
                     ],
                     [
                         "w-4/6",
-                        "width: 66.666667%;",
-                        ""
+                        "width: 66.666667%;"
                     ],
                     [
                         "w-5/6",
-                        "width: 83.333333%;",
-                        ""
+                        "width: 83.333333%;"
                     ],
                     [
                         "w-1/12",
-                        "width: 8.333333%;",
-                        ""
+                        "width: 8.333333%;"
                     ],
                     [
                         "w-2/12",
-                        "width: 16.666667%;",
-                        ""
+                        "width: 16.666667%;"
                     ],
                     [
                         "w-3/12",
-                        "width: 25%;",
-                        ""
+                        "width: 25%;"
                     ],
                     [
                         "w-4/12",
-                        "width: 33.333333%;",
-                        ""
+                        "width: 33.333333%;"
                     ],
                     [
                         "w-5/12",
-                        "width: 41.666667%;",
-                        ""
+                        "width: 41.666667%;"
                     ],
                     [
                         "w-6/12",
-                        "width: 50%;",
-                        ""
+                        "width: 50%;"
                     ],
                     [
                         "w-7/12",
-                        "width: 58.333333%;",
-                        ""
+                        "width: 58.333333%;"
                     ],
                     [
                         "w-8/12",
-                        "width: 66.666667%;",
-                        ""
+                        "width: 66.666667%;"
                     ],
                     [
                         "w-9/12",
-                        "width: 75%;",
-                        ""
+                        "width: 75%;"
                     ],
                     [
                         "w-10/12",
-                        "width: 83.333333%;",
-                        ""
+                        "width: 83.333333%;"
                     ],
                     [
                         "w-11/12",
-                        "width: 91.666667%;",
-                        ""
+                        "width: 91.666667%;"
                     ],
                     [
                         "w-full",
-                        "width: 100%;",
-                        ""
+                        "width: 100%;"
                     ],
                     [
                         "w-screen",
-                        "width: 100vw;",
-                        ""
+                        "width: 100vw;"
                     ],
                     [
                         "w-min",
-                        "width: min-content;",
-                        ""
+                        "width: min-content;"
                     ],
                     [
                         "w-max",
-                        "width: max-content;",
-                        ""
+                        "width: max-content;"
                     ],
                     [
                         "w-fit",
-                        "width: fit-content;",
-                        ""
+                        "width: fit-content;"
                     ]
                 ]
             },
@@ -13291,28 +11699,23 @@
                 "table": [
                     [
                         "min-w-0",
-                        "min-width: 0;",
-                        ""
+                        "min-width: 0;"
                     ],
                     [
                         "min-w-full",
-                        "min-width: 100%;",
-                        ""
+                        "min-width: 100%;"
                     ],
                     [
                         "min-w-min",
-                        "min-width: min-content;",
-                        ""
+                        "min-width: min-content;"
                     ],
                     [
                         "min-w-max",
-                        "min-width: max-content;",
-                        ""
+                        "min-width: max-content;"
                     ],
                     [
                         "min-w-fit",
-                        "min-width: fit-content;",
-                        ""
+                        "min-width: fit-content;"
                     ]
                 ]
             },
@@ -13323,13 +11726,11 @@
                 "table": [
                     [
                         "max-w-0",
-                        "max-width: 0rem;",
-                        ""
+                        "max-width: 0rem;"
                     ],
                     [
                         "max-w-none",
-                        "max-width: none;",
-                        ""
+                        "max-width: none;"
                     ],
                     [
                         "max-w-xs",
@@ -13388,53 +11789,43 @@
                     ],
                     [
                         "max-w-full",
-                        "max-width: 100%;",
-                        ""
+                        "max-width: 100%;"
                     ],
                     [
                         "max-w-min",
-                        "max-width: min-content;",
-                        ""
+                        "max-width: min-content;"
                     ],
                     [
                         "max-w-max",
-                        "max-width: max-content;",
-                        ""
+                        "max-width: max-content;"
                     ],
                     [
                         "max-w-fit",
-                        "max-width: fit-content;",
-                        ""
+                        "max-width: fit-content;"
                     ],
                     [
                         "max-w-prose",
-                        "max-width: 65ch;",
-                        ""
+                        "max-width: 65ch;"
                     ],
                     [
                         "max-w-screen-sm",
-                        "max-width: 640px;",
-                        ""
+                        "max-width: 640px;"
                     ],
                     [
                         "max-w-screen-md",
-                        "max-width: 768px;",
-                        ""
+                        "max-width: 768px;"
                     ],
                     [
                         "max-w-screen-lg",
-                        "max-width: 1024px;",
-                        ""
+                        "max-width: 1024px;"
                     ],
                     [
                         "max-w-screen-xl",
-                        "max-width: 1280px;",
-                        ""
+                        "max-width: 1280px;"
                     ],
                     [
                         "max-w-screen-2xl",
-                        "max-width: 1536px;",
-                        ""
+                        "max-width: 1536px;"
                     ]
                 ]
             },
@@ -13445,8 +11836,7 @@
                 "table": [
                     [
                         "h-0",
-                        "height: 0;",
-                        ""
+                        "height: 0;"
                     ],
                     [
                         "h-0.5",
@@ -13600,113 +11990,91 @@
                     ],
                     [
                         "h-px",
-                        "height: 1px;",
-                        ""
+                        "height: 1px;"
                     ],
                     [
                         "h-auto",
-                        "height: auto;",
-                        ""
+                        "height: auto;"
                     ],
                     [
                         "h-1/2",
-                        "height: 50%;",
-                        ""
+                        "height: 50%;"
                     ],
                     [
                         "h-1/3",
-                        "height: 33.333333%;",
-                        ""
+                        "height: 33.333333%;"
                     ],
                     [
                         "h-2/3",
-                        "height: 66.666667%;",
-                        ""
+                        "height: 66.666667%;"
                     ],
                     [
                         "h-1/4",
-                        "height: 25%;",
-                        ""
+                        "height: 25%;"
                     ],
                     [
                         "h-2/4",
-                        "height: 50%;",
-                        ""
+                        "height: 50%;"
                     ],
                     [
                         "h-3/4",
-                        "height: 75%;",
-                        ""
+                        "height: 75%;"
                     ],
                     [
                         "h-1/5",
-                        "height: 20%;",
-                        ""
+                        "height: 20%;"
                     ],
                     [
                         "h-2/5",
-                        "height: 40%;",
-                        ""
+                        "height: 40%;"
                     ],
                     [
                         "h-3/5",
-                        "height: 60%;",
-                        ""
+                        "height: 60%;"
                     ],
                     [
                         "h-4/5",
-                        "height: 80%;",
-                        ""
+                        "height: 80%;"
                     ],
                     [
                         "h-1/6",
-                        "height: 16.666667%;",
-                        ""
+                        "height: 16.666667%;"
                     ],
                     [
                         "h-2/6",
-                        "height: 33.333333%;",
-                        ""
+                        "height: 33.333333%;"
                     ],
                     [
                         "h-3/6",
-                        "height: 50%;",
-                        ""
+                        "height: 50%;"
                     ],
                     [
                         "h-4/6",
-                        "height: 66.666667%;",
-                        ""
+                        "height: 66.666667%;"
                     ],
                     [
                         "h-5/6",
-                        "height: 83.333333%;",
-                        ""
+                        "height: 83.333333%;"
                     ],
                     [
                         "h-full",
-                        "height: 100%;",
-                        ""
+                        "height: 100%;"
                     ],
                     [
                         "h-screen",
-                        "height: 100vh;",
-                        ""
+                        "height: 100vh;"
                     ],
                     [
                         "h-min",
-                        "height: min-content;",
-                        ""
+                        "height: min-content;"
                     ],
                     [
                         "h-max",
-                        "height: max-content;",
-                        ""
+                        "height: max-content;"
                     ],
                     [
                         "h-fit",
-                        "height: fit-content;",
-                        ""
+                        "height: fit-content;"
                     ]
                 ]
             },
@@ -13717,33 +12085,27 @@
                 "table": [
                     [
                         "min-h-0",
-                        "min-height: 0;",
-                        ""
+                        "min-height: 0;"
                     ],
                     [
                         "min-h-full",
-                        "min-height: 100%;",
-                        ""
+                        "min-height: 100%;"
                     ],
                     [
                         "min-h-screen",
-                        "min-height: 100vh;",
-                        ""
+                        "min-height: 100vh;"
                     ],
                     [
                         "min-h-min",
-                        "min-height: min-content;",
-                        ""
+                        "min-height: min-content;"
                     ],
                     [
                         "min-h-max",
-                        "min-height: max-content;",
-                        ""
+                        "min-height: max-content;"
                     ],
                     [
                         "min-h-fit",
-                        "min-height: fit-content;",
-                        ""
+                        "min-height: fit-content;"
                     ]
                 ]
             },
@@ -13754,8 +12116,7 @@
                 "table": [
                     [
                         "max-h-0",
-                        "max-height: 0;",
-                        ""
+                        "max-height: 0;"
                     ],
                     [
                         "max-h-0.5",
@@ -13909,33 +12270,27 @@
                     ],
                     [
                         "max-h-px",
-                        "max-height: 1px;",
-                        ""
+                        "max-height: 1px;"
                     ],
                     [
                         "max-h-full",
-                        "max-height: 100%;",
-                        ""
+                        "max-height: 100%;"
                     ],
                     [
                         "max-h-screen",
-                        "max-height: 100vh;",
-                        ""
+                        "max-height: 100vh;"
                     ],
                     [
                         "max-h-min",
-                        "max-height: min-content;",
-                        ""
+                        "max-height: min-content;"
                     ],
                     [
                         "max-h-max",
-                        "max-height: max-content;",
-                        ""
+                        "max-height: max-content;"
                     ],
                     [
                         "max-h-fit",
-                        "max-height: fit-content;",
-                        ""
+                        "max-height: fit-content;"
                     ]
                 ]
             }
@@ -13951,18 +12306,15 @@
                 "table": [
                     [
                         "font-sans",
-                        "font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\";",
-                        ""
+                        "font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\";"
                     ],
                     [
                         "font-serif",
-                        "font-family: Georgia, Cambria, \"Times New Roman\", Times, serif;",
-                        ""
+                        "font-family: Georgia, Cambria, \"Times New Roman\", Times, serif;"
                     ],
                     [
                         "font-mono",
-                        "font-family: Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace;",
-                        ""
+                        "font-family: Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace;"
                     ]
                 ]
             },
@@ -14045,13 +12397,11 @@
                 "table": [
                     [
                         "antialiased",
-                        "-webkit-font-smoothing: antialiased;\n-moz-osx-font-smoothing: grayscale;",
-                        ""
+                        "-webkit-font-smoothing: antialiased;\n-moz-osx-font-smoothing: grayscale;"
                     ],
                     [
                         "subpixel-antialiased",
-                        "-webkit-font-smoothing: auto;\n-moz-osx-font-smoothing: auto;",
-                        ""
+                        "-webkit-font-smoothing: auto;\n-moz-osx-font-smoothing: auto;"
                     ]
                 ]
             },
@@ -14062,13 +12412,11 @@
                 "table": [
                     [
                         "italic",
-                        "font-style: italic;",
-                        ""
+                        "font-style: italic;"
                     ],
                     [
                         "not-italic",
-                        "font-style: normal;",
-                        ""
+                        "font-style: normal;"
                     ]
                 ]
             },
@@ -14079,48 +12427,39 @@
                 "table": [
                     [
                         "font-thin",
-                        "font-weight: 100;",
-                        ""
+                        "font-weight: 100;"
                     ],
                     [
                         "font-extralight",
-                        "font-weight: 200;",
-                        ""
+                        "font-weight: 200;"
                     ],
                     [
                         "font-light",
-                        "font-weight: 300;",
-                        ""
+                        "font-weight: 300;"
                     ],
                     [
                         "font-normal",
-                        "font-weight: 400;",
-                        ""
+                        "font-weight: 400;"
                     ],
                     [
                         "font-medium",
-                        "font-weight: 500;",
-                        ""
+                        "font-weight: 500;"
                     ],
                     [
                         "font-semibold",
-                        "font-weight: 600;",
-                        ""
+                        "font-weight: 600;"
                     ],
                     [
                         "font-bold",
-                        "font-weight: 700;",
-                        ""
+                        "font-weight: 700;"
                     ],
                     [
                         "font-extrabold",
-                        "font-weight: 800;",
-                        ""
+                        "font-weight: 800;"
                     ],
                     [
                         "font-black",
-                        "font-weight: 900;",
-                        ""
+                        "font-weight: 900;"
                     ]
                 ]
             },
@@ -14131,48 +12470,39 @@
                 "table": [
                     [
                         "normal-nums",
-                        "font-variant-numeric: normal;",
-                        ""
+                        "font-variant-numeric: normal;"
                     ],
                     [
                         "ordinal",
-                        "font-variant-numeric: ordinal;",
-                        ""
+                        "font-variant-numeric: ordinal;"
                     ],
                     [
                         "slashed-zero",
-                        "font-variant-numeric: slashed-zero;",
-                        ""
+                        "font-variant-numeric: slashed-zero;"
                     ],
                     [
                         "lining-nums",
-                        "font-variant-numeric: lining-nums;",
-                        ""
+                        "font-variant-numeric: lining-nums;"
                     ],
                     [
                         "oldstyle-nums",
-                        "font-variant-numeric: oldstyle-nums;",
-                        ""
+                        "font-variant-numeric: oldstyle-nums;"
                     ],
                     [
                         "proportional-nums",
-                        "font-variant-numeric: proportional-nums;",
-                        ""
+                        "font-variant-numeric: proportional-nums;"
                     ],
                     [
                         "tabular-nums",
-                        "font-variant-numeric: tabular-nums;",
-                        ""
+                        "font-variant-numeric: tabular-nums;"
                     ],
                     [
                         "diagonal-fractions",
-                        "font-variant-numeric: diagonal-fractions;",
-                        ""
+                        "font-variant-numeric: diagonal-fractions;"
                     ],
                     [
                         "stacked-fractions",
-                        "font-variant-numeric: stacked-fractions;",
-                        ""
+                        "font-variant-numeric: stacked-fractions;"
                     ]
                 ]
             },
@@ -14183,33 +12513,27 @@
                 "table": [
                     [
                         "tracking-tighter",
-                        "letter-spacing: -0.05em;",
-                        ""
+                        "letter-spacing: -0.05em;"
                     ],
                     [
                         "tracking-tight",
-                        "letter-spacing: -0.025em;",
-                        ""
+                        "letter-spacing: -0.025em;"
                     ],
                     [
                         "tracking-normal",
-                        "letter-spacing: 0;",
-                        ""
+                        "letter-spacing: 0;"
                     ],
                     [
                         "tracking-wide",
-                        "letter-spacing: 0.025em;",
-                        ""
+                        "letter-spacing: 0.025em;"
                     ],
                     [
                         "tracking-wider",
-                        "letter-spacing: 0.05em;",
-                        ""
+                        "letter-spacing: 0.05em;"
                     ],
                     [
                         "tracking-widest",
-                        "letter-spacing: 0.1em;",
-                        ""
+                        "letter-spacing: 0.1em;"
                     ]
                 ]
             },
@@ -14220,33 +12544,27 @@
                 "table": [
                     [
                         "leading-none",
-                        "line-height: 1;",
-                        ""
+                        "line-height: 1;"
                     ],
                     [
                         "leading-tight",
-                        "line-height: 1.25;",
-                        ""
+                        "line-height: 1.25;"
                     ],
                     [
                         "leading-snug",
-                        "line-height: 1.375;",
-                        ""
+                        "line-height: 1.375;"
                     ],
                     [
                         "leading-normal",
-                        "line-height: 1.5;",
-                        ""
+                        "line-height: 1.5;"
                     ],
                     [
                         "leading-relaxed",
-                        "line-height: 1.625;",
-                        ""
+                        "line-height: 1.625;"
                     ],
                     [
                         "leading-loose",
-                        "line-height: 2;",
-                        ""
+                        "line-height: 2;"
                     ],
                     [
                         "leading-3",
@@ -14297,18 +12615,15 @@
                 "table": [
                     [
                         "list-none",
-                        "list-style-type: none;",
-                        ""
+                        "list-style-type: none;"
                     ],
                     [
                         "list-disc",
-                        "list-style-type: disc;",
-                        ""
+                        "list-style-type: disc;"
                     ],
                     [
                         "list-decimal",
-                        "list-style-type: decimal;",
-                        ""
+                        "list-style-type: decimal;"
                     ]
                 ]
             },
@@ -14319,13 +12634,11 @@
                 "table": [
                     [
                         "list-inside",
-                        "list-style-position: inside;",
-                        ""
+                        "list-style-position: inside;"
                     ],
                     [
                         "list-outside",
-                        "list-style-position: outside;",
-                        ""
+                        "list-style-position: outside;"
                     ]
                 ]
             },
@@ -14336,23 +12649,19 @@
                 "table": [
                     [
                         "text-left",
-                        "text-align: left;",
-                        ""
+                        "text-align: left;"
                     ],
                     [
                         "text-center",
-                        "text-align: center;",
-                        ""
+                        "text-align: center;"
                     ],
                     [
                         "text-right",
-                        "text-align: right;",
-                        ""
+                        "text-align: right;"
                     ],
                     [
                         "text-justify",
-                        "text-align: justify;",
-                        ""
+                        "text-align: justify;"
                     ]
                 ]
             },
@@ -14364,506 +12673,422 @@
                     [
                         "transparent",
                         "text-transparent",
-                        "color: transparent;",
-                        ""
+                        "color: transparent;"
                     ],
                     [
                         "current color",
                         "text-current",
-                        "color: currentColor;",
-                        ""
+                        "color: currentColor;"
                     ],
                     [
                         "rgb(0, 0, 0)",
                         "text-black",
-                        "color: #000000;",
-                        ""
+                        "color: #000000;"
                     ],
                     [
                         "rgb(255, 255, 255)",
                         "text-white",
-                        "color: #ffffff;",
-                        ""
+                        "color: #ffffff;"
                     ],
                     [
                         "rgb(249, 250, 251)",
                         "text-gray-50",
-                        "color: #F9FAFB;",
-                        ""
+                        "color: #F9FAFB;"
                     ],
                     [
                         "rgb(243, 244, 246)",
                         "text-gray-100",
-                        "color: #F3F4F6;",
-                        ""
+                        "color: #F3F4F6;"
                     ],
                     [
                         "rgb(229, 231, 235)",
                         "text-gray-200",
-                        "color: #E5E7EB;",
-                        ""
+                        "color: #E5E7EB;"
                     ],
                     [
                         "rgb(209, 213, 219)",
                         "text-gray-300",
-                        "color: #D1D5DB;",
-                        ""
+                        "color: #D1D5DB;"
                     ],
                     [
                         "rgb(156, 163, 175)",
                         "text-gray-400",
-                        "color: #9CA3AF;",
-                        ""
+                        "color: #9CA3AF;"
                     ],
                     [
                         "rgb(107, 114, 128)",
                         "text-gray-500",
-                        "color: #6B7280;",
-                        ""
+                        "color: #6B7280;"
                     ],
                     [
                         "rgb(75, 85, 99)",
                         "text-gray-600",
-                        "color: #4B5563;",
-                        ""
+                        "color: #4B5563;"
                     ],
                     [
                         "rgb(55, 65, 81)",
                         "text-gray-700",
-                        "color: #374151;",
-                        ""
+                        "color: #374151;"
                     ],
                     [
                         "rgb(31, 41, 55)",
                         "text-gray-800",
-                        "color: #1F2937;",
-                        ""
+                        "color: #1F2937;"
                     ],
                     [
                         "rgb(17, 24, 39)",
                         "text-gray-900",
-                        "color: #111827;",
-                        ""
+                        "color: #111827;"
                     ],
                     [
                         "rgb(254, 242, 242)",
                         "text-red-50",
-                        "color: #FEF2F2;",
-                        ""
+                        "color: #FEF2F2;"
                     ],
                     [
                         "rgb(254, 226, 226)",
                         "text-red-100",
-                        "color: #FEE2E2;",
-                        ""
+                        "color: #FEE2E2;"
                     ],
                     [
                         "rgb(254, 202, 202)",
                         "text-red-200",
-                        "color: #FECACA;",
-                        ""
+                        "color: #FECACA;"
                     ],
                     [
                         "rgb(252, 165, 165)",
                         "text-red-300",
-                        "color: #FCA5A5;",
-                        ""
+                        "color: #FCA5A5;"
                     ],
                     [
                         "rgb(248, 113, 113)",
                         "text-red-400",
-                        "color: #F87171;",
-                        ""
+                        "color: #F87171;"
                     ],
                     [
                         "rgb(239, 68, 68)",
                         "text-red-500",
-                        "color: #EF4444;",
-                        ""
+                        "color: #EF4444;"
                     ],
                     [
                         "rgb(220, 38, 38)",
                         "text-red-600",
-                        "color: #DC2626;",
-                        ""
+                        "color: #DC2626;"
                     ],
                     [
                         "rgb(185, 28, 28)",
                         "text-red-700",
-                        "color: #B91C1C;",
-                        ""
+                        "color: #B91C1C;"
                     ],
                     [
                         "rgb(153, 27, 27)",
                         "text-red-800",
-                        "color: #991B1B;",
-                        ""
+                        "color: #991B1B;"
                     ],
                     [
                         "rgb(127, 29, 29)",
                         "text-red-900",
-                        "color: #7F1D1D;",
-                        ""
+                        "color: #7F1D1D;"
                     ],
                     [
                         "rgb(255, 251, 235)",
                         "text-yellow-50",
-                        "color: #FFFBEB;",
-                        ""
+                        "color: #FFFBEB;"
                     ],
                     [
                         "rgb(254, 243, 199)",
                         "text-yellow-100",
-                        "color: #FEF3C7;",
-                        ""
+                        "color: #FEF3C7;"
                     ],
                     [
                         "rgb(253, 230, 138)",
                         "text-yellow-200",
-                        "color: #FDE68A;",
-                        ""
+                        "color: #FDE68A;"
                     ],
                     [
                         "rgb(252, 211, 77)",
                         "text-yellow-300",
-                        "color: #FCD34D;",
-                        ""
+                        "color: #FCD34D;"
                     ],
                     [
                         "rgb(251, 191, 36)",
                         "text-yellow-400",
-                        "color: #FBBF24;",
-                        ""
+                        "color: #FBBF24;"
                     ],
                     [
                         "rgb(245, 158, 11)",
                         "text-yellow-500",
-                        "color: #F59E0B;",
-                        ""
+                        "color: #F59E0B;"
                     ],
                     [
                         "rgb(217, 119, 6)",
                         "text-yellow-600",
-                        "color: #D97706;",
-                        ""
+                        "color: #D97706;"
                     ],
                     [
                         "rgb(180, 83, 9)",
                         "text-yellow-700",
-                        "color: #B45309;",
-                        ""
+                        "color: #B45309;"
                     ],
                     [
                         "rgb(146, 64, 14)",
                         "text-yellow-800",
-                        "color: #92400E;",
-                        ""
+                        "color: #92400E;"
                     ],
                     [
                         "rgb(120, 53, 15)",
                         "text-yellow-900",
-                        "color: #78350F;",
-                        ""
+                        "color: #78350F;"
                     ],
                     [
                         "rgb(236, 253, 245)",
                         "text-green-50",
-                        "color: #ECFDF5;",
-                        ""
+                        "color: #ECFDF5;"
                     ],
                     [
                         "rgb(209, 250, 229)",
                         "text-green-100",
-                        "color: #D1FAE5;",
-                        ""
+                        "color: #D1FAE5;"
                     ],
                     [
                         "rgb(167, 243, 208)",
                         "text-green-200",
-                        "color: #A7F3D0;",
-                        ""
+                        "color: #A7F3D0;"
                     ],
                     [
                         "rgb(110, 231, 183)",
                         "text-green-300",
-                        "color: #6EE7B7;",
-                        ""
+                        "color: #6EE7B7;"
                     ],
                     [
                         "rgb(52, 211, 153)",
                         "text-green-400",
-                        "color: #34D399;",
-                        ""
+                        "color: #34D399;"
                     ],
                     [
                         "rgb(16, 185, 129)",
                         "text-green-500",
-                        "color: #10B981;",
-                        ""
+                        "color: #10B981;"
                     ],
                     [
                         "rgb(5, 150, 105)",
                         "text-green-600",
-                        "color: #059669;",
-                        ""
+                        "color: #059669;"
                     ],
                     [
                         "rgb(4, 120, 87)",
                         "text-green-700",
-                        "color: #047857;",
-                        ""
+                        "color: #047857;"
                     ],
                     [
                         "rgb(6, 95, 70)",
                         "text-green-800",
-                        "color: #065F46;",
-                        ""
+                        "color: #065F46;"
                     ],
                     [
                         "rgb(6, 78, 59)",
                         "text-green-900",
-                        "color: #064E3B;",
-                        ""
+                        "color: #064E3B;"
                     ],
                     [
                         "rgb(239, 246, 255)",
                         "text-blue-50",
-                        "color: #EFF6FF;",
-                        ""
+                        "color: #EFF6FF;"
                     ],
                     [
                         "rgb(219, 234, 254)",
                         "text-blue-100",
-                        "color: #DBEAFE;",
-                        ""
+                        "color: #DBEAFE;"
                     ],
                     [
                         "rgb(191, 219, 254)",
                         "text-blue-200",
-                        "color: #BFDBFE;",
-                        ""
+                        "color: #BFDBFE;"
                     ],
                     [
                         "rgb(147, 197, 253)",
                         "text-blue-300",
-                        "color: #93C5FD;",
-                        ""
+                        "color: #93C5FD;"
                     ],
                     [
                         "rgb(96, 165, 250)",
                         "text-blue-400",
-                        "color: #60A5FA;",
-                        ""
+                        "color: #60A5FA;"
                     ],
                     [
                         "rgb(59, 130, 246)",
                         "text-blue-500",
-                        "color: #3B82F6;",
-                        ""
+                        "color: #3B82F6;"
                     ],
                     [
                         "rgb(37, 99, 235)",
                         "text-blue-600",
-                        "color: #2563EB;",
-                        ""
+                        "color: #2563EB;"
                     ],
                     [
                         "rgb(29, 78, 216)",
                         "text-blue-700",
-                        "color: #1D4ED8;",
-                        ""
+                        "color: #1D4ED8;"
                     ],
                     [
                         "rgb(30, 64, 175)",
                         "text-blue-800",
-                        "color: #1E40AF;",
-                        ""
+                        "color: #1E40AF;"
                     ],
                     [
                         "rgb(30, 58, 138)",
                         "text-blue-900",
-                        "color: #1E3A8A;",
-                        ""
+                        "color: #1E3A8A;"
                     ],
                     [
                         "rgb(238, 242, 255)",
                         "text-indigo-50",
-                        "color: #EEF2FF;",
-                        ""
+                        "color: #EEF2FF;"
                     ],
                     [
                         "rgb(224, 231, 255)",
                         "text-indigo-100",
-                        "color: #E0E7FF;",
-                        ""
+                        "color: #E0E7FF;"
                     ],
                     [
                         "rgb(199, 210, 254)",
                         "text-indigo-200",
-                        "color: #C7D2FE;",
-                        ""
+                        "color: #C7D2FE;"
                     ],
                     [
                         "rgb(165, 180, 252)",
                         "text-indigo-300",
-                        "color: #A5B4FC;",
-                        ""
+                        "color: #A5B4FC;"
                     ],
                     [
                         "rgb(129, 140, 248)",
                         "text-indigo-400",
-                        "color: #818CF8;",
-                        ""
+                        "color: #818CF8;"
                     ],
                     [
                         "rgb(99, 102, 241)",
                         "text-indigo-500",
-                        "color: #6366F1;",
-                        ""
+                        "color: #6366F1;"
                     ],
                     [
                         "rgb(79, 70, 229)",
                         "text-indigo-600",
-                        "color: #4F46E5;",
-                        ""
+                        "color: #4F46E5;"
                     ],
                     [
                         "rgb(67, 56, 202)",
                         "text-indigo-700",
-                        "color: #4338CA;",
-                        ""
+                        "color: #4338CA;"
                     ],
                     [
                         "rgb(55, 48, 163)",
                         "text-indigo-800",
-                        "color: #3730A3;",
-                        ""
+                        "color: #3730A3;"
                     ],
                     [
                         "rgb(49, 46, 129)",
                         "text-indigo-900",
-                        "color: #312E81;",
-                        ""
+                        "color: #312E81;"
                     ],
                     [
                         "rgb(245, 243, 255)",
                         "text-purple-50",
-                        "color: #F5F3FF;",
-                        ""
+                        "color: #F5F3FF;"
                     ],
                     [
                         "rgb(237, 233, 254)",
                         "text-purple-100",
-                        "color: #EDE9FE;",
-                        ""
+                        "color: #EDE9FE;"
                     ],
                     [
                         "rgb(221, 214, 254)",
                         "text-purple-200",
-                        "color: #DDD6FE;",
-                        ""
+                        "color: #DDD6FE;"
                     ],
                     [
                         "rgb(196, 181, 253)",
                         "text-purple-300",
-                        "color: #C4B5FD;",
-                        ""
+                        "color: #C4B5FD;"
                     ],
                     [
                         "rgb(167, 139, 250)",
                         "text-purple-400",
-                        "color: #A78BFA;",
-                        ""
+                        "color: #A78BFA;"
                     ],
                     [
                         "rgb(139, 92, 246)",
                         "text-purple-500",
-                        "color: #8B5CF6;",
-                        ""
+                        "color: #8B5CF6;"
                     ],
                     [
                         "rgb(124, 58, 237)",
                         "text-purple-600",
-                        "color: #7C3AED;",
-                        ""
+                        "color: #7C3AED;"
                     ],
                     [
                         "rgb(109, 40, 217)",
                         "text-purple-700",
-                        "color: #6D28D9;",
-                        ""
+                        "color: #6D28D9;"
                     ],
                     [
                         "rgb(91, 33, 182)",
                         "text-purple-800",
-                        "color: #5B21B6;",
-                        ""
+                        "color: #5B21B6;"
                     ],
                     [
                         "rgb(76, 29, 149)",
                         "text-purple-900",
-                        "color: #4C1D95;",
-                        ""
+                        "color: #4C1D95;"
                     ],
                     [
                         "rgb(253, 242, 248)",
                         "text-pink-50",
-                        "color: #FDF2F8;",
-                        ""
+                        "color: #FDF2F8;"
                     ],
                     [
                         "rgb(252, 231, 243)",
                         "text-pink-100",
-                        "color: #FCE7F3;",
-                        ""
+                        "color: #FCE7F3;"
                     ],
                     [
                         "rgb(251, 207, 232)",
                         "text-pink-200",
-                        "color: #FBCFE8;",
-                        ""
+                        "color: #FBCFE8;"
                     ],
                     [
                         "rgb(249, 168, 212)",
                         "text-pink-300",
-                        "color: #F9A8D4;",
-                        ""
+                        "color: #F9A8D4;"
                     ],
                     [
                         "rgb(244, 114, 182)",
                         "text-pink-400",
-                        "color: #F472B6;",
-                        ""
+                        "color: #F472B6;"
                     ],
                     [
                         "rgb(236, 72, 153)",
                         "text-pink-500",
-                        "color: #EC4899;",
-                        ""
+                        "color: #EC4899;"
                     ],
                     [
                         "rgb(219, 39, 119)",
                         "text-pink-600",
-                        "color: #DB2777;",
-                        ""
+                        "color: #DB2777;"
                     ],
                     [
                         "rgb(190, 24, 93)",
                         "text-pink-700",
-                        "color: #BE185D;",
-                        ""
+                        "color: #BE185D;"
                     ],
                     [
                         "rgb(157, 23, 77)",
                         "text-pink-800",
-                        "color: #9D174D;",
-                        ""
+                        "color: #9D174D;"
                     ],
                     [
                         "rgb(131, 24, 67)",
                         "text-pink-900",
-                        "color: #831843;",
-                        ""
+                        "color: #831843;"
                     ]
                 ]
             },
@@ -14874,23 +13099,19 @@
                 "table": [
                     [
                         "underline",
-                        "text-decoration: underline;",
-                        ""
+                        "text-decoration: underline;"
                     ],
                     [
                         "overline",
-                        "text-decoration: overline;",
-                        ""
+                        "text-decoration: overline;"
                     ],
                     [
                         "line-through",
-                        "text-decoration: line-through;",
-                        ""
+                        "text-decoration: line-through;"
                     ],
                     [
                         "no-underline",
-                        "text-decoration: none;",
-                        ""
+                        "text-decoration: none;"
                     ]
                 ]
             },
@@ -14901,28 +13122,23 @@
                 "table": [
                     [
                         "decoration-solid",
-                        "text-decoration-style: solid;",
-                        ""
+                        "text-decoration-style: solid;"
                     ],
                     [
                         "decoration-double",
-                        "text-decoration-style: double;",
-                        ""
+                        "text-decoration-style: double;"
                     ],
                     [
                         "decoration-dotted",
-                        "text-decoration-style: dotted;",
-                        ""
+                        "text-decoration-style: dotted;"
                     ],
                     [
                         "decoration-dashed",
-                        "text-decoration-style: dashed;",
-                        ""
+                        "text-decoration-style: dashed;"
                     ],
                     [
                         "decoration-wavy",
-                        "text-decoration-style: wavy;",
-                        ""
+                        "text-decoration-style: wavy;"
                     ]
                 ]
             },
@@ -14933,38 +13149,31 @@
                 "table": [
                     [
                         "decoration-auto",
-                        "text-decoration-thickness: auto;",
-                        ""
+                        "text-decoration-thickness: auto;"
                     ],
                     [
                         "decoration-from-font",
-                        "text-decoration-thickness: from-font;",
-                        ""
+                        "text-decoration-thickness: from-font;"
                     ],
                     [
                         "decoration-0",
-                        "text-decoration-thickness: 0px;",
-                        ""
+                        "text-decoration-thickness: 0px;"
                     ],
                     [
                         "decoration-1",
-                        "text-decoration-thickness: 1px;",
-                        ""
+                        "text-decoration-thickness: 1px;"
                     ],
                     [
                         "decoration-2",
-                        "text-decoration-thickness: 2px;",
-                        ""
+                        "text-decoration-thickness: 2px;"
                     ],
                     [
                         "decoration-4",
-                        "text-decoration-thickness: 4px;",
-                        ""
+                        "text-decoration-thickness: 4px;"
                     ],
                     [
                         "decoration-8",
-                        "text-decoration-thickness: 8px;",
-                        ""
+                        "text-decoration-thickness: 8px;"
                     ]
                 ]
             },
@@ -14975,38 +13184,31 @@
                 "table": [
                     [
                         "underline-offset-auto",
-                        "text-underline-offset: auto;",
-                        ""
+                        "text-underline-offset: auto;"
                     ],
                     [
                         "underline-offset-from-font",
-                        "text-underline-offset: from-font;",
-                        ""
+                        "text-underline-offset: from-font;"
                     ],
                     [
                         "underline-offset-0",
-                        "text-underline-offset: 0px;",
-                        ""
+                        "text-underline-offset: 0px;"
                     ],
                     [
                         "underline-offset-1",
-                        "text-underline-offset: 1px;",
-                        ""
+                        "text-underline-offset: 1px;"
                     ],
                     [
                         "underline-offset-2",
-                        "text-underline-offset: 2px;",
-                        ""
+                        "text-underline-offset: 2px;"
                     ],
                     [
                         "underline-offset-4",
-                        "text-underline-offset: 4px;",
-                        ""
+                        "text-underline-offset: 4px;"
                     ],
                     [
                         "underline-offset-8",
-                        "text-underline-offset: 8px;",
-                        ""
+                        "text-underline-offset: 8px;"
                     ]
                 ]
             },
@@ -15017,23 +13219,19 @@
                 "table": [
                     [
                         "uppercase",
-                        "text-transform: uppercase;",
-                        ""
+                        "text-transform: uppercase;"
                     ],
                     [
                         "lowercase",
-                        "text-transform: lowercase;",
-                        ""
+                        "text-transform: lowercase;"
                     ],
                     [
                         "capitalize",
-                        "text-transform: capitalize;",
-                        ""
+                        "text-transform: capitalize;"
                     ],
                     [
                         "normal-case",
-                        "text-transform: none;",
-                        ""
+                        "text-transform: none;"
                     ]
                 ]
             },
@@ -15044,18 +13242,15 @@
                 "table": [
                     [
                         "truncate",
-                        "overflow: hidden;\ntext-overflow: ellipsis;\nwhite-space: nowrap;",
-                        ""
+                        "overflow: hidden;\ntext-overflow: ellipsis;\nwhite-space: nowrap;"
                     ],
                     [
                         "text-ellipsis",
-                        "text-overflow: ellipsis;",
-                        ""
+                        "text-overflow: ellipsis;"
                     ],
                     [
                         "text-clip",
-                        "text-overflow: clip;",
-                        ""
+                        "text-overflow: clip;"
                     ]
                 ]
             },
@@ -15066,8 +13261,7 @@
                 "table": [
                     [
                         "indent-0",
-                        "text-indent: 0;",
-                        ""
+                        "text-indent: 0;"
                     ],
                     [
                         "indent-0.5",
@@ -15221,8 +13415,7 @@
                     ],
                     [
                         "indent-px",
-                        "text-indent: 1px;",
-                        ""
+                        "text-indent: 1px;"
                     ]
                 ]
             },
@@ -15233,43 +13426,35 @@
                 "table": [
                     [
                         "align-baseline",
-                        "vertical-align: baseline;",
-                        ""
+                        "vertical-align: baseline;"
                     ],
                     [
                         "align-top",
-                        "vertical-align: top;",
-                        ""
+                        "vertical-align: top;"
                     ],
                     [
                         "align-middle",
-                        "vertical-align: middle;",
-                        ""
+                        "vertical-align: middle;"
                     ],
                     [
                         "align-bottom",
-                        "vertical-align: bottom;",
-                        ""
+                        "vertical-align: bottom;"
                     ],
                     [
                         "align-text-top",
-                        "vertical-align: text-top;",
-                        ""
+                        "vertical-align: text-top;"
                     ],
                     [
                         "align-text-bottom",
-                        "vertical-align: text-bottom;",
-                        ""
+                        "vertical-align: text-bottom;"
                     ],
                     [
                         "align-sub",
-                        "vertical-align: sub;",
-                        ""
+                        "vertical-align: sub;"
                     ],
                     [
                         "align-super",
-                        "vertical-align: super;",
-                        ""
+                        "vertical-align: super;"
                     ]
                 ]
             },
@@ -15280,28 +13465,23 @@
                 "table": [
                     [
                         "whitespace-normal",
-                        "white-space: normal;",
-                        ""
+                        "white-space: normal;"
                     ],
                     [
                         "whitespace-nowrap",
-                        "white-space: nowrap;",
-                        ""
+                        "white-space: nowrap;"
                     ],
                     [
                         "whitespace-pre",
-                        "white-space: pre;",
-                        ""
+                        "white-space: pre;"
                     ],
                     [
                         "whitespace-pre-line",
-                        "white-space: pre-line;",
-                        ""
+                        "white-space: pre-line;"
                     ],
                     [
                         "whitespace-pre-wrap",
-                        "white-space: pre-wrap;",
-                        ""
+                        "white-space: pre-wrap;"
                     ]
                 ]
             },
@@ -15312,18 +13492,15 @@
                 "table": [
                     [
                         "break-normal",
-                        "overflow-wrap: normal;\nword-break: normal;",
-                        ""
+                        "overflow-wrap: normal;\nword-break: normal;"
                     ],
                     [
                         "break-words",
-                        "overflow-wrap: break-word;",
-                        ""
+                        "overflow-wrap: break-word;"
                     ],
                     [
                         "break-all",
-                        "word-break: break-all;",
-                        ""
+                        "word-break: break-all;"
                     ]
                 ]
             },
@@ -15334,8 +13511,7 @@
                 "table": [
                     [
                         "content-none",
-                        "content: none;",
-                        ""
+                        "content: none;"
                     ]
                 ]
             }
@@ -15351,18 +13527,15 @@
                 "table": [
                     [
                         "bg-fixed",
-                        "background-attachment: fixed;",
-                        ""
+                        "background-attachment: fixed;"
                     ],
                     [
                         "bg-local",
-                        "background-attachment: local;",
-                        ""
+                        "background-attachment: local;"
                     ],
                     [
                         "bg-scroll",
-                        "background-attachment: scroll;",
-                        ""
+                        "background-attachment: scroll;"
                     ]
                 ]
             },
@@ -15373,23 +13546,19 @@
                 "table": [
                     [
                         "bg-clip-border",
-                        "background-clip: border-box;",
-                        ""
+                        "background-clip: border-box;"
                     ],
                     [
                         "bg-clip-padding",
-                        "background-clip: padding-box;",
-                        ""
+                        "background-clip: padding-box;"
                     ],
                     [
                         "bg-clip-content",
-                        "background-clip: content-box;",
-                        ""
+                        "background-clip: content-box;"
                     ],
                     [
                         "bg-clip-text",
-                        "background-clip: text;",
-                        ""
+                        "background-clip: text;"
                     ]
                 ]
             },
@@ -15401,506 +13570,422 @@
                     [
                         "transparent",
                         "bg-transparent",
-                        "background-color: transparent;",
-                        ""
+                        "background-color: transparent;"
                     ],
                     [
                         "current color",
                         "bg-current",
-                        "background-color: currentColor;",
-                        ""
+                        "background-color: currentColor;"
                     ],
                     [
                         "rgb(0, 0, 0)",
                         "bg-black",
-                        "background-color: #000000;",
-                        ""
+                        "background-color: #000000;"
                     ],
                     [
                         "rgb(255, 255, 255)",
                         "bg-white",
-                        "background-color: #ffffff;",
-                        ""
+                        "background-color: #ffffff;"
                     ],
                     [
                         "rgb(249, 250, 251)",
                         "bg-gray-50",
-                        "background-color: #F9FAFB;",
-                        ""
+                        "background-color: #F9FAFB;"
                     ],
                     [
                         "rgb(243, 244, 246)",
                         "bg-gray-100",
-                        "background-color: #F3F4F6;",
-                        ""
+                        "background-color: #F3F4F6;"
                     ],
                     [
                         "rgb(229, 231, 235)",
                         "bg-gray-200",
-                        "background-color: #E5E7EB;",
-                        ""
+                        "background-color: #E5E7EB;"
                     ],
                     [
                         "rgb(209, 213, 219)",
                         "bg-gray-300",
-                        "background-color: #D1D5DB;",
-                        ""
+                        "background-color: #D1D5DB;"
                     ],
                     [
                         "rgb(156, 163, 175)",
                         "bg-gray-400",
-                        "background-color: #9CA3AF;",
-                        ""
+                        "background-color: #9CA3AF;"
                     ],
                     [
                         "rgb(107, 114, 128)",
                         "bg-gray-500",
-                        "background-color: #6B7280;",
-                        ""
+                        "background-color: #6B7280;"
                     ],
                     [
                         "rgb(75, 85, 99)",
                         "bg-gray-600",
-                        "background-color: #6B7280;",
-                        ""
+                        "background-color: #6B7280;"
                     ],
                     [
                         "rgb(55, 65, 81)",
                         "bg-gray-700",
-                        "background-color: #374151;",
-                        ""
+                        "background-color: #374151;"
                     ],
                     [
                         "rgb(31, 41, 55)",
                         "bg-gray-800",
-                        "background-color: #1F2937;",
-                        ""
+                        "background-color: #1F2937;"
                     ],
                     [
                         "rgb(17, 24, 39)",
                         "bg-gray-900",
-                        "background-color: #111827;",
-                        ""
+                        "background-color: #111827;"
                     ],
                     [
                         "rgb(254, 242, 242)",
                         "bg-red-50",
-                        "background-color: #FEF2F2;",
-                        ""
+                        "background-color: #FEF2F2;"
                     ],
                     [
                         "rgb(254, 226, 226)",
                         "bg-red-100",
-                        "background-color: #FEE2E2;",
-                        ""
+                        "background-color: #FEE2E2;"
                     ],
                     [
                         "rgb(254, 202, 202)",
                         "bg-red-200",
-                        "background-color: #FECACA;",
-                        ""
+                        "background-color: #FECACA;"
                     ],
                     [
                         "rgb(252, 165, 165)",
                         "bg-red-300",
-                        "background-color: #FCA5A5;",
-                        ""
+                        "background-color: #FCA5A5;"
                     ],
                     [
                         "rgb(248, 113, 113)",
                         "bg-red-400",
-                        "background-color: #F87171;",
-                        ""
+                        "background-color: #F87171;"
                     ],
                     [
                         "rgb(239, 68, 68)",
                         "bg-red-500",
-                        "background-color: #EF4444;",
-                        ""
+                        "background-color: #EF4444;"
                     ],
                     [
                         "rgb(220, 38, 38)",
                         "bg-red-600",
-                        "background-color: #DC2626;",
-                        ""
+                        "background-color: #DC2626;"
                     ],
                     [
                         "rgb(185, 28, 28)",
                         "bg-red-700",
-                        "background-color: #B91C1C;",
-                        ""
+                        "background-color: #B91C1C;"
                     ],
                     [
                         "rgb(153, 27, 27)",
                         "bg-red-800",
-                        "background-color: #991B1B;",
-                        ""
+                        "background-color: #991B1B;"
                     ],
                     [
                         "rgb(127, 29, 29)",
                         "bg-red-900",
-                        "background-color: #7F1D1D;",
-                        ""
+                        "background-color: #7F1D1D;"
                     ],
                     [
                         "rgb(255, 251, 235)",
                         "bg-yellow-50",
-                        "background-color: #FFFBEB;",
-                        ""
+                        "background-color: #FFFBEB;"
                     ],
                     [
                         "rgb(254, 243, 199)",
                         "bg-yellow-100",
-                        "background-color: #FEF3C7;",
-                        ""
+                        "background-color: #FEF3C7;"
                     ],
                     [
                         "rgb(253, 230, 138)",
                         "bg-yellow-200",
-                        "background-color: #FDE68A;",
-                        ""
+                        "background-color: #FDE68A;"
                     ],
                     [
                         "rgb(252, 211, 77)",
                         "bg-yellow-300",
-                        "background-color: #FCD34D;",
-                        ""
+                        "background-color: #FCD34D;"
                     ],
                     [
                         "rgb(251, 191, 36)",
                         "bg-yellow-400",
-                        "background-color: #FBBF24;",
-                        ""
+                        "background-color: #FBBF24;"
                     ],
                     [
                         "rgb(245, 158, 11)",
                         "bg-yellow-500",
-                        "background-color: #F59E0B;",
-                        ""
+                        "background-color: #F59E0B;"
                     ],
                     [
                         "rgb(217, 119, 6)",
                         "bg-yellow-600",
-                        "background-color: #D97706;",
-                        ""
+                        "background-color: #D97706;"
                     ],
                     [
                         "rgb(180, 83, 9)",
                         "bg-yellow-700",
-                        "background-color: #B45309;",
-                        ""
+                        "background-color: #B45309;"
                     ],
                     [
                         "rgb(146, 64, 14)",
                         "bg-yellow-800",
-                        "background-color: #92400E;",
-                        ""
+                        "background-color: #92400E;"
                     ],
                     [
                         "rgb(120, 53, 15)",
                         "bg-yellow-900",
-                        "background-color: #78350F;",
-                        ""
+                        "background-color: #78350F;"
                     ],
                     [
                         "rgb(236, 253, 245)",
                         "bg-green-50",
-                        "background-color: #ECFDF5;",
-                        ""
+                        "background-color: #ECFDF5;"
                     ],
                     [
                         "rgb(209, 250, 229)",
                         "bg-green-100",
-                        "background-color: #D1FAE5;",
-                        ""
+                        "background-color: #D1FAE5;"
                     ],
                     [
                         "rgb(167, 243, 208)",
                         "bg-green-200",
-                        "background-color: #A7F3D0;",
-                        ""
+                        "background-color: #A7F3D0;"
                     ],
                     [
                         "rgb(110, 231, 183)",
                         "bg-green-300",
-                        "background-color: #6EE7B7;",
-                        ""
+                        "background-color: #6EE7B7;"
                     ],
                     [
                         "rgb(52, 211, 153)",
                         "bg-green-400",
-                        "background-color: #34D399;",
-                        ""
+                        "background-color: #34D399;"
                     ],
                     [
                         "rgb(16, 185, 129)",
                         "bg-green-500",
-                        "background-color: #10B981;",
-                        ""
+                        "background-color: #10B981;"
                     ],
                     [
                         "rgb(5, 150, 105)",
                         "bg-green-600",
-                        "background-color: #059669;",
-                        ""
+                        "background-color: #059669;"
                     ],
                     [
                         "rgb(4, 120, 87)",
                         "bg-green-700",
-                        "background-color: #047857;",
-                        ""
+                        "background-color: #047857;"
                     ],
                     [
                         "rgb(6, 95, 70)",
                         "bg-green-800",
-                        "background-color: #065F46;",
-                        ""
+                        "background-color: #065F46;"
                     ],
                     [
                         "rgb(6, 78, 59)",
                         "bg-green-900",
-                        "background-color: #064E3B;",
-                        ""
+                        "background-color: #064E3B;"
                     ],
                     [
                         "rgb(239, 246, 255)",
                         "bg-blue-50",
-                        "background-color: #EFF6FF;",
-                        ""
+                        "background-color: #EFF6FF;"
                     ],
                     [
                         "rgb(219, 234, 254)",
                         "bg-blue-100",
-                        "background-color: #DBEAFE;",
-                        ""
+                        "background-color: #DBEAFE;"
                     ],
                     [
                         "rgb(191, 219, 254)",
                         "bg-blue-200",
-                        "background-color: #BFDBFE;",
-                        ""
+                        "background-color: #BFDBFE;"
                     ],
                     [
                         "rgb(147, 197, 253)",
                         "bg-blue-300",
-                        "background-color: #93C5FD;",
-                        ""
+                        "background-color: #93C5FD;"
                     ],
                     [
                         "rgb(96, 165, 250)",
                         "bg-blue-400",
-                        "background-color: #60A5FA;",
-                        ""
+                        "background-color: #60A5FA;"
                     ],
                     [
                         "rgb(59, 130, 246)",
                         "bg-blue-500",
-                        "background-color: #3B82F6;",
-                        ""
+                        "background-color: #3B82F6;"
                     ],
                     [
                         "rgb(37, 99, 235)",
                         "bg-blue-600",
-                        "background-color: #2563EB;",
-                        ""
+                        "background-color: #2563EB;"
                     ],
                     [
                         "rgb(29, 78, 216)",
                         "bg-blue-700",
-                        "background-color: #1D4ED8;",
-                        ""
+                        "background-color: #1D4ED8;"
                     ],
                     [
                         "rgb(30, 64, 175)",
                         "bg-blue-800",
-                        "background-color: #1E40AF;",
-                        ""
+                        "background-color: #1E40AF;"
                     ],
                     [
                         "rgb(30, 58, 138)",
                         "bg-blue-900",
-                        "background-color: #1E3A8A;",
-                        ""
+                        "background-color: #1E3A8A;"
                     ],
                     [
                         "rgb(238, 242, 255)",
                         "bg-indigo-50",
-                        "background-color: #EEF2FF;",
-                        ""
+                        "background-color: #EEF2FF;"
                     ],
                     [
                         "rgb(224, 231, 255)",
                         "bg-indigo-100",
-                        "background-color: #E0E7FF;",
-                        ""
+                        "background-color: #E0E7FF;"
                     ],
                     [
                         "rgb(199, 210, 254)",
                         "bg-indigo-200",
-                        "background-color: #C7D2FE;",
-                        ""
+                        "background-color: #C7D2FE;"
                     ],
                     [
                         "rgb(165, 180, 252)",
                         "bg-indigo-300",
-                        "background-color: #A5B4FC;",
-                        ""
+                        "background-color: #A5B4FC;"
                     ],
                     [
                         "rgb(129, 140, 248)",
                         "bg-indigo-400",
-                        "background-color: #818CF8;",
-                        ""
+                        "background-color: #818CF8;"
                     ],
                     [
                         "rgb(99, 102, 241)",
                         "bg-indigo-500",
-                        "background-color: #6366F1;",
-                        ""
+                        "background-color: #6366F1;"
                     ],
                     [
                         "rgb(79, 70, 229)",
                         "bg-indigo-600",
-                        "background-color: #4F46E5;",
-                        ""
+                        "background-color: #4F46E5;"
                     ],
                     [
                         "rgb(67, 56, 202)",
                         "bg-indigo-700",
-                        "background-color: #4338CA;",
-                        ""
+                        "background-color: #4338CA;"
                     ],
                     [
                         "rgb(55, 48, 163)",
                         "bg-indigo-800",
-                        "background-color: #3730A3;",
-                        ""
+                        "background-color: #3730A3;"
                     ],
                     [
                         "rgb(49, 46, 129)",
                         "bg-indigo-900",
-                        "background-color: #312E81;",
-                        ""
+                        "background-color: #312E81;"
                     ],
                     [
                         "rgb(245, 243, 255)",
                         "bg-purple-50",
-                        "background-color: #F5F3FF;",
-                        ""
+                        "background-color: #F5F3FF;"
                     ],
                     [
                         "rgb(237, 233, 254)",
                         "bg-purple-100",
-                        "background-color: #EDE9FE;",
-                        ""
+                        "background-color: #EDE9FE;"
                     ],
                     [
                         "rgb(221, 214, 254)",
                         "bg-purple-200",
-                        "background-color: #DDD6FE;",
-                        ""
+                        "background-color: #DDD6FE;"
                     ],
                     [
                         "rgb(196, 181, 253)",
                         "bg-purple-300",
-                        "background-color: #C4B5FD;",
-                        ""
+                        "background-color: #C4B5FD;"
                     ],
                     [
                         "rgb(167, 139, 250)",
                         "bg-purple-400",
-                        "background-color: #A78BFA;",
-                        ""
+                        "background-color: #A78BFA;"
                     ],
                     [
                         "rgb(139, 92, 246)",
                         "bg-purple-500",
-                        "background-color: #8B5CF6;",
-                        ""
+                        "background-color: #8B5CF6;"
                     ],
                     [
                         "rgb(124, 58, 237)",
                         "bg-purple-600",
-                        "background-color: #7C3AED;",
-                        ""
+                        "background-color: #7C3AED;"
                     ],
                     [
                         "rgb(109, 40, 217)",
                         "bg-purple-700",
-                        "background-color: #6D28D9;",
-                        ""
+                        "background-color: #6D28D9;"
                     ],
                     [
                         "rgb(91, 33, 182)",
                         "bg-purple-800",
-                        "background-color: #5B21B6;",
-                        ""
+                        "background-color: #5B21B6;"
                     ],
                     [
                         "rgb(76, 29, 149)",
                         "bg-purple-900",
-                        "background-color: #4C1D95;",
-                        ""
+                        "background-color: #4C1D95;"
                     ],
                     [
                         "rgb(253, 242, 248)",
                         "bg-pink-50",
-                        "background-color: #FDF2F8;",
-                        ""
+                        "background-color: #FDF2F8;"
                     ],
                     [
                         "rgb(252, 231, 243)",
                         "bg-pink-100",
-                        "background-color: #FCE7F3;",
-                        ""
+                        "background-color: #FCE7F3;"
                     ],
                     [
                         "rgb(251, 207, 232)",
                         "bg-pink-200",
-                        "background-color: #FBCFE8;",
-                        ""
+                        "background-color: #FBCFE8;"
                     ],
                     [
                         "rgb(249, 168, 212)",
                         "bg-pink-300",
-                        "background-color: #F9A8D4;",
-                        ""
+                        "background-color: #F9A8D4;"
                     ],
                     [
                         "rgb(244, 114, 182)",
                         "bg-pink-400",
-                        "background-color: #F472B6;",
-                        ""
+                        "background-color: #F472B6;"
                     ],
                     [
                         "rgb(236, 72, 153)",
                         "bg-pink-500",
-                        "background-color: #EC4899;",
-                        ""
+                        "background-color: #EC4899;"
                     ],
                     [
                         "rgb(219, 39, 119)",
                         "bg-pink-600",
-                        "background-color: #DB2777;",
-                        ""
+                        "background-color: #DB2777;"
                     ],
                     [
                         "rgb(190, 24, 93)",
                         "bg-pink-700",
-                        "background-color: #BE185D;",
-                        ""
+                        "background-color: #BE185D;"
                     ],
                     [
                         "rgb(157, 23, 77)",
                         "bg-pink-800",
-                        "background-color: #9D174D;",
-                        ""
+                        "background-color: #9D174D;"
                     ],
                     [
                         "rgb(131, 24, 67)",
                         "bg-pink-900",
-                        "background-color: #831843;",
-                        ""
+                        "background-color: #831843;"
                     ]
                 ]
             },
@@ -15911,78 +13996,63 @@
                 "table": [
                     [
                         "bg-opacity-0",
-                        "--bg-opacity: 0;",
-                        ""
+                        "--bg-opacity: 0;"
                     ],
                     [
                         "bg-opacity-5",
-                        "--bg-opacity: 0.5;",
-                        ""
+                        "--bg-opacity: 0.5;"
                     ],
                     [
                         "bg-opacity-10",
-                        "--bg-opacity: 0.1;",
-                        ""
+                        "--bg-opacity: 0.1;"
                     ],
                     [
                         "bg-opacity-20",
-                        "--bg-opacity: 0.2;",
-                        ""
+                        "--bg-opacity: 0.2;"
                     ],
                     [
                         "bg-opacity-25",
-                        "--bg-opacity: 0.25;",
-                        ""
+                        "--bg-opacity: 0.25;"
                     ],
                     [
                         "bg-opacity-30",
-                        "--bg-opacity: 0.3;",
-                        ""
+                        "--bg-opacity: 0.3;"
                     ],
                     [
                         "bg-opacity-40",
-                        "--bg-opacity: 0.4;",
-                        ""
+                        "--bg-opacity: 0.4;"
                     ],
                     [
                         "bg-opacity-50",
-                        "--bg-opacity: 0.5;",
-                        ""
+                        "--bg-opacity: 0.5;"
                     ],
                     [
                         "bg-opacity-60",
-                        "--bg-opacity: 0.6;",
-                        ""
+                        "--bg-opacity: 0.6;"
                     ],
                     [
                         "bg-opacity-70",
-                        "--bg-opacity: 0.7;",
-                        ""
+                        "--bg-opacity: 0.7;"
                     ],
                     [
                         "bg-opacity-75",
-                        "--bg-opacity: 0.75;",
-                        ""
+                        "--bg-opacity: 0.75;"
                     ],
                     [
                         "bg-opacity-80",
-                        "--bg-opacity: 0.8;",
-                        ""
+                        "--bg-opacity: 0.8;"
                     ],
                     [
                         "bg-opacity-90",
-                        "--bg-opacity: 0.9;",
-                        ""
+                        "--bg-opacity: 0.9;"
                     ],
                     [
                         "bg-opacity-95",
-                        "--bg-opacity: 0.95;",
-                        ""
+                        "--bg-opacity: 0.95;"
                     ],
                     [
                         "bg-opacity-100",
-                        "--bg-opacity: 1;",
-                        ""
+                        "--bg-opacity: 1;"
                     ]
                 ]
             },
@@ -15993,18 +14063,15 @@
                 "table": [
                     [
                         "bg-origin-border",
-                        "background-origin: border-box;",
-                        ""
+                        "background-origin: border-box;"
                     ],
                     [
                         "bg-origin-padding",
-                        "background-origin: padding-box;",
-                        ""
+                        "background-origin: padding-box;"
                     ],
                     [
                         "bg-origin-content",
-                        "background-origin: content-box;",
-                        ""
+                        "background-origin: content-box;"
                     ]
                 ]
             },
@@ -16015,48 +14082,39 @@
                 "table": [
                     [
                         "bg-bottom",
-                        "background-position: bottom;",
-                        ""
+                        "background-position: bottom;"
                     ],
                     [
                         "bg-center",
-                        "background-position: center;",
-                        ""
+                        "background-position: center;"
                     ],
                     [
                         "bg-left",
-                        "background-position: left;",
-                        ""
+                        "background-position: left;"
                     ],
                     [
                         "bg-left-bottom",
-                        "background-position: left bottom;",
-                        ""
+                        "background-position: left bottom;"
                     ],
                     [
                         "bg-left-top",
-                        "background-position: left top;",
-                        ""
+                        "background-position: left top;"
                     ],
                     [
                         "bg-right",
-                        "background-position: right;",
-                        ""
+                        "background-position: right;"
                     ],
                     [
                         "bg-right-bottom",
-                        "background-position: right bottom;",
-                        ""
+                        "background-position: right bottom;"
                     ],
                     [
                         "bg-right-top",
-                        "background-position: right top;",
-                        ""
+                        "background-position: right top;"
                     ],
                     [
                         "bg-top",
-                        "background-position: top;",
-                        ""
+                        "background-position: top;"
                     ]
                 ]
             },
@@ -16067,33 +14125,27 @@
                 "table": [
                     [
                         "bg-repeat",
-                        "background-repeat: repeat;",
-                        ""
+                        "background-repeat: repeat;"
                     ],
                     [
                         "bg-no-repeat",
-                        "background-repeat: no-repeat;",
-                        ""
+                        "background-repeat: no-repeat;"
                     ],
                     [
                         "bg-repeat-x",
-                        "background-repeat: repeat-x;",
-                        ""
+                        "background-repeat: repeat-x;"
                     ],
                     [
                         "bg-repeat-y",
-                        "background-repeat: repeat-y;",
-                        ""
+                        "background-repeat: repeat-y;"
                     ],
                     [
                         "bg-repeat-round",
-                        "background-repeat: round;",
-                        ""
+                        "background-repeat: round;"
                     ],
                     [
                         "bg-repeat-space",
-                        "background-repeat: space;",
-                        ""
+                        "background-repeat: space;"
                     ]
                 ]
             },
@@ -16104,18 +14156,15 @@
                 "table": [
                     [
                         "bg-auto",
-                        "background-size: auto;",
-                        ""
+                        "background-size: auto;"
                     ],
                     [
                         "bg-cover",
-                        "background-size: cover;",
-                        ""
+                        "background-size: cover;"
                     ],
                     [
                         "bg-contain",
-                        "background-size: contain;",
-                        ""
+                        "background-size: contain;"
                     ]
                 ]
             },
@@ -16126,48 +14175,39 @@
                 "table": [
                     [
                         "bg-none",
-                        "background-image: none;",
-                        ""
+                        "background-image: none;"
                     ],
                     [
                         "bg-gradient-to-t",
-                        "background-image:background-image: background-image: linear-gradient(to top, var(--tw-gradient-stops));",
-                        ""
+                        "background-image:background-image: background-image: linear-gradient(to top, var(--tw-gradient-stops));"
                     ],
                     [
                         "bg-gradient-to-tr",
-                        "background-image: background-image: linear-gradient(to top right, var(--tw-gradient-stops));",
-                        ""
+                        "background-image: background-image: linear-gradient(to top right, var(--tw-gradient-stops));"
                     ],
                     [
                         "bg-gradient-to-r",
-                        "background-image: background-image: linear-gradient(to right, var(--tw-gradient-stops));",
-                        ""
+                        "background-image: background-image: linear-gradient(to right, var(--tw-gradient-stops));"
                     ],
                     [
                         "bg-gradient-to-br",
-                        "background-image: background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));",
-                        ""
+                        "background-image: background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));"
                     ],
                     [
                         "bg-gradient-to-b",
-                        "background-image: background-image: linear-gradient(to bottom, var(--tw-gradient-stops));",
-                        ""
+                        "background-image: background-image: linear-gradient(to bottom, var(--tw-gradient-stops));"
                     ],
                     [
                         "bg-gradient-to-bl",
-                        "background-image: background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));",
-                        ""
+                        "background-image: background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));"
                     ],
                     [
                         "bg-gradient-to-l",
-                        "background-image: background-image: linear-gradient(to left, var(--tw-gradient-stops));",
-                        ""
+                        "background-image: background-image: linear-gradient(to left, var(--tw-gradient-stops));"
                     ],
                     [
                         "bg-gradient-to-tl",
-                        "background-image: background-image: linear-gradient(to top left, var(--tw-gradient-stops));",
-                        ""
+                        "background-image: background-image: linear-gradient(to top left, var(--tw-gradient-stops));"
                     ]
                 ]
             },
@@ -16179,1514 +14219,1262 @@
                     [
                         "transparent",
                         "from-transparent",
-                        "background-color: transparent;",
-                        ""
+                        "background-color: transparent;"
                     ],
                     [
                         "current color",
                         "from-current",
-                        "background-color: currentColor;",
-                        ""
+                        "background-color: currentColor;"
                     ],
                     [
                         "rgb(0, 0, 0)",
                         "from-black",
-                        "background-color: #000000;",
-                        ""
+                        "background-color: #000000;"
                     ],
                     [
                         "rgb(255, 255, 255)",
                         "from-white",
-                        "background-color: #ffffff;",
-                        ""
+                        "background-color: #ffffff;"
                     ],
                     [
                         "rgb(249, 250, 251)",
                         "from-gray-50",
-                        "background-color: #F9FAFB;",
-                        ""
+                        "background-color: #F9FAFB;"
                     ],
                     [
                         "rgb(243, 244, 246)",
                         "from-gray-100",
-                        "background-color: #F3F4F6;",
-                        ""
+                        "background-color: #F3F4F6;"
                     ],
                     [
                         "rgb(229, 231, 235)",
                         "from-gray-200",
-                        "background-color: #E5E7EB;",
-                        ""
+                        "background-color: #E5E7EB;"
                     ],
                     [
                         "rgb(209, 213, 219)",
                         "from-gray-300",
-                        "background-color: #D1D5DB;",
-                        ""
+                        "background-color: #D1D5DB;"
                     ],
                     [
                         "rgb(156, 163, 175)",
                         "from-gray-400",
-                        "background-color: #9CA3AF;",
-                        ""
+                        "background-color: #9CA3AF;"
                     ],
                     [
                         "rgb(107, 114, 128)",
                         "from-gray-500",
-                        "background-color: #6B7280;",
-                        ""
+                        "background-color: #6B7280;"
                     ],
                     [
                         "rgb(75, 85, 99)",
                         "from-gray-600",
-                        "background-color: #6B7280;",
-                        ""
+                        "background-color: #6B7280;"
                     ],
                     [
                         "rgb(55, 65, 81)",
                         "from-gray-700",
-                        "background-color: #374151;",
-                        ""
+                        "background-color: #374151;"
                     ],
                     [
                         "rgb(31, 41, 55)",
                         "from-gray-800",
-                        "background-color: #1F2937;",
-                        ""
+                        "background-color: #1F2937;"
                     ],
                     [
                         "rgb(17, 24, 39)",
                         "from-gray-900",
-                        "background-color: #111827;",
-                        ""
+                        "background-color: #111827;"
                     ],
                     [
                         "rgb(254, 242, 242)",
                         "from-red-50",
-                        "background-color: #FEF2F2;",
-                        ""
+                        "background-color: #FEF2F2;"
                     ],
                     [
                         "rgb(254, 226, 226)",
                         "from-red-100",
-                        "background-color: #FEE2E2;",
-                        ""
+                        "background-color: #FEE2E2;"
                     ],
                     [
                         "rgb(254, 202, 202)",
                         "from-red-200",
-                        "background-color: #FECACA;",
-                        ""
+                        "background-color: #FECACA;"
                     ],
                     [
                         "rgb(252, 165, 165)",
                         "from-red-300",
-                        "background-color: #FCA5A5;",
-                        ""
+                        "background-color: #FCA5A5;"
                     ],
                     [
                         "rgb(248, 113, 113)",
                         "from-red-400",
-                        "background-color: #F87171;",
-                        ""
+                        "background-color: #F87171;"
                     ],
                     [
                         "rgb(239, 68, 68)",
                         "from-red-500",
-                        "background-color: #EF4444;",
-                        ""
+                        "background-color: #EF4444;"
                     ],
                     [
                         "rgb(220, 38, 38)",
                         "from-red-600",
-                        "background-color: #DC2626;",
-                        ""
+                        "background-color: #DC2626;"
                     ],
                     [
                         "rgb(185, 28, 28)",
                         "from-red-700",
-                        "background-color: #B91C1C;",
-                        ""
+                        "background-color: #B91C1C;"
                     ],
                     [
                         "rgb(153, 27, 27)",
                         "from-red-800",
-                        "background-color: #991B1B;",
-                        ""
+                        "background-color: #991B1B;"
                     ],
                     [
                         "rgb(127, 29, 29)",
                         "from-red-900",
-                        "background-color: #7F1D1D;",
-                        ""
+                        "background-color: #7F1D1D;"
                     ],
                     [
                         "rgb(255, 251, 235)",
                         "from-yellow-50",
-                        "background-color: #FFFBEB;",
-                        ""
+                        "background-color: #FFFBEB;"
                     ],
                     [
                         "rgb(254, 243, 199)",
                         "from-yellow-100",
-                        "background-color: #FEF3C7;",
-                        ""
+                        "background-color: #FEF3C7;"
                     ],
                     [
                         "rgb(253, 230, 138)",
                         "from-yellow-200",
-                        "background-color: #FDE68A;",
-                        ""
+                        "background-color: #FDE68A;"
                     ],
                     [
                         "rgb(252, 211, 77)",
                         "from-yellow-300",
-                        "background-color: #FCD34D;",
-                        ""
+                        "background-color: #FCD34D;"
                     ],
                     [
                         "rgb(251, 191, 36)",
                         "from-yellow-400",
-                        "background-color: #FBBF24;",
-                        ""
+                        "background-color: #FBBF24;"
                     ],
                     [
                         "rgb(245, 158, 11)",
                         "from-yellow-500",
-                        "background-color: #F59E0B;",
-                        ""
+                        "background-color: #F59E0B;"
                     ],
                     [
                         "rgb(217, 119, 6)",
                         "from-yellow-600",
-                        "background-color: #D97706;",
-                        ""
+                        "background-color: #D97706;"
                     ],
                     [
                         "rgb(180, 83, 9)",
                         "from-yellow-700",
-                        "background-color: #B45309;",
-                        ""
+                        "background-color: #B45309;"
                     ],
                     [
                         "rgb(146, 64, 14)",
                         "from-yellow-800",
-                        "background-color: #92400E;",
-                        ""
+                        "background-color: #92400E;"
                     ],
                     [
                         "rgb(120, 53, 15)",
                         "from-yellow-900",
-                        "background-color: #78350F;",
-                        ""
+                        "background-color: #78350F;"
                     ],
                     [
                         "rgb(236, 253, 245)",
                         "from-green-50",
-                        "background-color: #ECFDF5;",
-                        ""
+                        "background-color: #ECFDF5;"
                     ],
                     [
                         "rgb(209, 250, 229)",
                         "from-green-100",
-                        "background-color: #D1FAE5;",
-                        ""
+                        "background-color: #D1FAE5;"
                     ],
                     [
                         "rgb(167, 243, 208)",
                         "from-green-200",
-                        "background-color: #A7F3D0;",
-                        ""
+                        "background-color: #A7F3D0;"
                     ],
                     [
                         "rgb(110, 231, 183)",
                         "from-green-300",
-                        "background-color: #6EE7B7;",
-                        ""
+                        "background-color: #6EE7B7;"
                     ],
                     [
                         "rgb(52, 211, 153)",
                         "from-green-400",
-                        "background-color: #34D399;",
-                        ""
+                        "background-color: #34D399;"
                     ],
                     [
                         "rgb(16, 185, 129)",
                         "from-green-500",
-                        "background-color: #10B981;",
-                        ""
+                        "background-color: #10B981;"
                     ],
                     [
                         "rgb(5, 150, 105)",
                         "from-green-600",
-                        "background-color: #059669;",
-                        ""
+                        "background-color: #059669;"
                     ],
                     [
                         "rgb(4, 120, 87)",
                         "from-green-700",
-                        "background-color: #047857;",
-                        ""
+                        "background-color: #047857;"
                     ],
                     [
                         "rgb(6, 95, 70)",
                         "from-green-800",
-                        "background-color: #065F46;",
-                        ""
+                        "background-color: #065F46;"
                     ],
                     [
                         "rgb(6, 78, 59)",
                         "from-green-900",
-                        "background-color: #064E3B;",
-                        ""
+                        "background-color: #064E3B;"
                     ],
                     [
                         "rgb(239, 246, 255)",
                         "from-blue-50",
-                        "background-color: #EFF6FF;",
-                        ""
+                        "background-color: #EFF6FF;"
                     ],
                     [
                         "rgb(219, 234, 254)",
                         "from-blue-100",
-                        "background-color: #DBEAFE;",
-                        ""
+                        "background-color: #DBEAFE;"
                     ],
                     [
                         "rgb(191, 219, 254)",
                         "from-blue-200",
-                        "background-color: #BFDBFE;",
-                        ""
+                        "background-color: #BFDBFE;"
                     ],
                     [
                         "rgb(147, 197, 253)",
                         "from-blue-300",
-                        "background-color: #93C5FD;",
-                        ""
+                        "background-color: #93C5FD;"
                     ],
                     [
                         "rgb(96, 165, 250)",
                         "from-blue-400",
-                        "background-color: #60A5FA;",
-                        ""
+                        "background-color: #60A5FA;"
                     ],
                     [
                         "rgb(59, 130, 246)",
                         "from-blue-500",
-                        "background-color: #3B82F6;",
-                        ""
+                        "background-color: #3B82F6;"
                     ],
                     [
                         "rgb(37, 99, 235)",
                         "from-blue-600",
-                        "background-color: #2563EB;",
-                        ""
+                        "background-color: #2563EB;"
                     ],
                     [
                         "rgb(29, 78, 216)",
                         "from-blue-700",
-                        "background-color: #1D4ED8;",
-                        ""
+                        "background-color: #1D4ED8;"
                     ],
                     [
                         "rgb(30, 64, 175)",
                         "from-blue-800",
-                        "background-color: #1E40AF;",
-                        ""
+                        "background-color: #1E40AF;"
                     ],
                     [
                         "rgb(30, 58, 138)",
                         "from-blue-900",
-                        "background-color: #1E3A8A;",
-                        ""
+                        "background-color: #1E3A8A;"
                     ],
                     [
                         "rgb(238, 242, 255)",
                         "from-indigo-50",
-                        "background-color: #EEF2FF;",
-                        ""
+                        "background-color: #EEF2FF;"
                     ],
                     [
                         "rgb(224, 231, 255)",
                         "from-indigo-100",
-                        "background-color: #E0E7FF;",
-                        ""
+                        "background-color: #E0E7FF;"
                     ],
                     [
                         "rgb(199, 210, 254)",
                         "from-indigo-200",
-                        "background-color: #C7D2FE;",
-                        ""
+                        "background-color: #C7D2FE;"
                     ],
                     [
                         "rgb(165, 180, 252)",
                         "from-indigo-300",
-                        "background-color: #A5B4FC;",
-                        ""
+                        "background-color: #A5B4FC;"
                     ],
                     [
                         "rgb(129, 140, 248)",
                         "from-indigo-400",
-                        "background-color: #818CF8;",
-                        ""
+                        "background-color: #818CF8;"
                     ],
                     [
                         "rgb(99, 102, 241)",
                         "from-indigo-500",
-                        "background-color: #6366F1;",
-                        ""
+                        "background-color: #6366F1;"
                     ],
                     [
                         "rgb(79, 70, 229)",
                         "from-indigo-600",
-                        "background-color: #4F46E5;",
-                        ""
+                        "background-color: #4F46E5;"
                     ],
                     [
                         "rgb(67, 56, 202)",
                         "from-indigo-700",
-                        "background-color: #4338CA;",
-                        ""
+                        "background-color: #4338CA;"
                     ],
                     [
                         "rgb(55, 48, 163)",
                         "from-indigo-800",
-                        "background-color: #3730A3;",
-                        ""
+                        "background-color: #3730A3;"
                     ],
                     [
                         "rgb(49, 46, 129)",
                         "from-indigo-900",
-                        "background-color: #312E81;",
-                        ""
+                        "background-color: #312E81;"
                     ],
                     [
                         "rgb(245, 243, 255)",
                         "from-purple-50",
-                        "background-color: #F5F3FF;",
-                        ""
+                        "background-color: #F5F3FF;"
                     ],
                     [
                         "rgb(237, 233, 254)",
                         "from-purple-100",
-                        "background-color: #EDE9FE;",
-                        ""
+                        "background-color: #EDE9FE;"
                     ],
                     [
                         "rgb(221, 214, 254)",
                         "from-purple-200",
-                        "background-color: #DDD6FE;",
-                        ""
+                        "background-color: #DDD6FE;"
                     ],
                     [
                         "rgb(196, 181, 253)",
                         "from-purple-300",
-                        "background-color: #C4B5FD;",
-                        ""
+                        "background-color: #C4B5FD;"
                     ],
                     [
                         "rgb(167, 139, 250)",
                         "from-purple-400",
-                        "background-color: #A78BFA;",
-                        ""
+                        "background-color: #A78BFA;"
                     ],
                     [
                         "rgb(139, 92, 246)",
                         "from-purple-500",
-                        "background-color: #8B5CF6;",
-                        ""
+                        "background-color: #8B5CF6;"
                     ],
                     [
                         "rgb(124, 58, 237)",
                         "from-purple-600",
-                        "background-color: #7C3AED;",
-                        ""
+                        "background-color: #7C3AED;"
                     ],
                     [
                         "rgb(109, 40, 217)",
                         "from-purple-700",
-                        "background-color: #6D28D9;",
-                        ""
+                        "background-color: #6D28D9;"
                     ],
                     [
                         "rgb(91, 33, 182)",
                         "from-purple-800",
-                        "background-color: #5B21B6;",
-                        ""
+                        "background-color: #5B21B6;"
                     ],
                     [
                         "rgb(76, 29, 149)",
                         "from-purple-900",
-                        "background-color: #4C1D95;",
-                        ""
+                        "background-color: #4C1D95;"
                     ],
                     [
                         "rgb(253, 242, 248)",
                         "from-pink-50",
-                        "background-color: #FDF2F8;",
-                        ""
+                        "background-color: #FDF2F8;"
                     ],
                     [
                         "rgb(252, 231, 243)",
                         "from-pink-100",
-                        "background-color: #FCE7F3;",
-                        ""
+                        "background-color: #FCE7F3;"
                     ],
                     [
                         "rgb(251, 207, 232)",
                         "from-pink-200",
-                        "background-color: #FBCFE8;",
-                        ""
+                        "background-color: #FBCFE8;"
                     ],
                     [
                         "rgb(249, 168, 212)",
                         "from-pink-300",
-                        "background-color: #F9A8D4;",
-                        ""
+                        "background-color: #F9A8D4;"
                     ],
                     [
                         "rgb(244, 114, 182)",
                         "from-pink-400",
-                        "background-color: #F472B6;",
-                        ""
+                        "background-color: #F472B6;"
                     ],
                     [
                         "rgb(236, 72, 153)",
                         "from-pink-500",
-                        "background-color: #EC4899;",
-                        ""
+                        "background-color: #EC4899;"
                     ],
                     [
                         "rgb(219, 39, 119)",
                         "from-pink-600",
-                        "background-color: #DB2777;",
-                        ""
+                        "background-color: #DB2777;"
                     ],
                     [
                         "rgb(190, 24, 93)",
                         "from-pink-700",
-                        "background-color: #BE185D;",
-                        ""
+                        "background-color: #BE185D;"
                     ],
                     [
                         "rgb(157, 23, 77)",
                         "from-pink-800",
-                        "background-color: #9D174D;",
-                        ""
+                        "background-color: #9D174D;"
                     ],
                     [
                         "rgb(131, 24, 67)",
                         "from-pink-900",
-                        "background-color: #831843;",
-                        ""
+                        "background-color: #831843;"
                     ],
                     [
                         "transparent",
                         "via-transparent",
-                        "background-color: transparent;",
-                        ""
+                        "background-color: transparent;"
                     ],
                     [
                         "current color",
                         "via-current",
-                        "background-color: currentColor;",
-                        ""
+                        "background-color: currentColor;"
                     ],
                     [
                         "rgb(0, 0, 0)",
                         "via-black",
-                        "background-color: #000000;",
-                        ""
+                        "background-color: #000000;"
                     ],
                     [
                         "rgb(255, 255, 255)",
                         "via-white",
-                        "background-color: #ffffff;",
-                        ""
+                        "background-color: #ffffff;"
                     ],
                     [
                         "rgb(249, 250, 251)",
                         "via-gray-50",
-                        "background-color: #F9FAFB;",
-                        ""
+                        "background-color: #F9FAFB;"
                     ],
                     [
                         "rgb(243, 244, 246)",
                         "via-gray-100",
-                        "background-color: #F3F4F6;",
-                        ""
+                        "background-color: #F3F4F6;"
                     ],
                     [
                         "rgb(229, 231, 235)",
                         "via-gray-200",
-                        "background-color: #E5E7EB;",
-                        ""
+                        "background-color: #E5E7EB;"
                     ],
                     [
                         "rgb(209, 213, 219)",
                         "via-gray-300",
-                        "background-color: #D1D5DB;",
-                        ""
+                        "background-color: #D1D5DB;"
                     ],
                     [
                         "rgb(156, 163, 175)",
                         "via-gray-400",
-                        "background-color: #9CA3AF;",
-                        ""
+                        "background-color: #9CA3AF;"
                     ],
                     [
                         "rgb(107, 114, 128)",
                         "via-gray-500",
-                        "background-color: #6B7280;",
-                        ""
+                        "background-color: #6B7280;"
                     ],
                     [
                         "rgb(75, 85, 99)",
                         "via-gray-600",
-                        "background-color: #6B7280;",
-                        ""
+                        "background-color: #6B7280;"
                     ],
                     [
                         "rgb(55, 65, 81)",
                         "via-gray-700",
-                        "background-color: #374151;",
-                        ""
+                        "background-color: #374151;"
                     ],
                     [
                         "rgb(31, 41, 55)",
                         "via-gray-800",
-                        "background-color: #1F2937;",
-                        ""
+                        "background-color: #1F2937;"
                     ],
                     [
                         "rgb(17, 24, 39)",
                         "via-gray-900",
-                        "background-color: #111827;",
-                        ""
+                        "background-color: #111827;"
                     ],
                     [
                         "rgb(254, 242, 242)",
                         "via-red-50",
-                        "background-color: #FEF2F2;",
-                        ""
+                        "background-color: #FEF2F2;"
                     ],
                     [
                         "rgb(254, 226, 226)",
                         "via-red-100",
-                        "background-color: #FEE2E2;",
-                        ""
+                        "background-color: #FEE2E2;"
                     ],
                     [
                         "rgb(254, 202, 202)",
                         "via-red-200",
-                        "background-color: #FECACA;",
-                        ""
+                        "background-color: #FECACA;"
                     ],
                     [
                         "rgb(252, 165, 165)",
                         "via-red-300",
-                        "background-color: #FCA5A5;",
-                        ""
+                        "background-color: #FCA5A5;"
                     ],
                     [
                         "rgb(248, 113, 113)",
                         "via-red-400",
-                        "background-color: #F87171;",
-                        ""
+                        "background-color: #F87171;"
                     ],
                     [
                         "rgb(239, 68, 68)",
                         "via-red-500",
-                        "background-color: #EF4444;",
-                        ""
+                        "background-color: #EF4444;"
                     ],
                     [
                         "rgb(220, 38, 38)",
                         "via-red-600",
-                        "background-color: #DC2626;",
-                        ""
+                        "background-color: #DC2626;"
                     ],
                     [
                         "rgb(185, 28, 28)",
                         "via-red-700",
-                        "background-color: #B91C1C;",
-                        ""
+                        "background-color: #B91C1C;"
                     ],
                     [
                         "rgb(153, 27, 27)",
                         "via-red-800",
-                        "background-color: #991B1B;",
-                        ""
+                        "background-color: #991B1B;"
                     ],
                     [
                         "rgb(127, 29, 29)",
                         "via-red-900",
-                        "background-color: #7F1D1D;",
-                        ""
+                        "background-color: #7F1D1D;"
                     ],
                     [
                         "rgb(255, 251, 235)",
                         "via-yellow-50",
-                        "background-color: #FFFBEB;",
-                        ""
+                        "background-color: #FFFBEB;"
                     ],
                     [
                         "rgb(254, 243, 199)",
                         "via-yellow-100",
-                        "background-color: #FEF3C7;",
-                        ""
+                        "background-color: #FEF3C7;"
                     ],
                     [
                         "rgb(253, 230, 138)",
                         "via-yellow-200",
-                        "background-color: #FDE68A;",
-                        ""
+                        "background-color: #FDE68A;"
                     ],
                     [
                         "rgb(252, 211, 77)",
                         "via-yellow-300",
-                        "background-color: #FCD34D;",
-                        ""
+                        "background-color: #FCD34D;"
                     ],
                     [
                         "rgb(251, 191, 36)",
                         "via-yellow-400",
-                        "background-color: #FBBF24;",
-                        ""
+                        "background-color: #FBBF24;"
                     ],
                     [
                         "rgb(245, 158, 11)",
                         "via-yellow-500",
-                        "background-color: #F59E0B;",
-                        ""
+                        "background-color: #F59E0B;"
                     ],
                     [
                         "rgb(217, 119, 6)",
                         "via-yellow-600",
-                        "background-color: #D97706;",
-                        ""
+                        "background-color: #D97706;"
                     ],
                     [
                         "rgb(180, 83, 9)",
                         "via-yellow-700",
-                        "background-color: #B45309;",
-                        ""
+                        "background-color: #B45309;"
                     ],
                     [
                         "rgb(146, 64, 14)",
                         "via-yellow-800",
-                        "background-color: #92400E;",
-                        ""
+                        "background-color: #92400E;"
                     ],
                     [
                         "rgb(120, 53, 15)",
                         "via-yellow-900",
-                        "background-color: #78350F;",
-                        ""
+                        "background-color: #78350F;"
                     ],
                     [
                         "rgb(236, 253, 245)",
                         "via-green-50",
-                        "background-color: #ECFDF5;",
-                        ""
+                        "background-color: #ECFDF5;"
                     ],
                     [
                         "rgb(209, 250, 229)",
                         "via-green-100",
-                        "background-color: #D1FAE5;",
-                        ""
+                        "background-color: #D1FAE5;"
                     ],
                     [
                         "rgb(167, 243, 208)",
                         "via-green-200",
-                        "background-color: #A7F3D0;",
-                        ""
+                        "background-color: #A7F3D0;"
                     ],
                     [
                         "rgb(110, 231, 183)",
                         "via-green-300",
-                        "background-color: #6EE7B7;",
-                        ""
+                        "background-color: #6EE7B7;"
                     ],
                     [
                         "rgb(52, 211, 153)",
                         "via-green-400",
-                        "background-color: #34D399;",
-                        ""
+                        "background-color: #34D399;"
                     ],
                     [
                         "rgb(16, 185, 129)",
                         "via-green-500",
-                        "background-color: #10B981;",
-                        ""
+                        "background-color: #10B981;"
                     ],
                     [
                         "rgb(5, 150, 105)",
                         "via-green-600",
-                        "background-color: #059669;",
-                        ""
+                        "background-color: #059669;"
                     ],
                     [
                         "rgb(4, 120, 87)",
                         "via-green-700",
-                        "background-color: #047857;",
-                        ""
+                        "background-color: #047857;"
                     ],
                     [
                         "rgb(6, 95, 70)",
                         "via-green-800",
-                        "background-color: #065F46;",
-                        ""
+                        "background-color: #065F46;"
                     ],
                     [
                         "rgb(6, 78, 59)",
                         "via-green-900",
-                        "background-color: #064E3B;",
-                        ""
+                        "background-color: #064E3B;"
                     ],
                     [
                         "rgb(239, 246, 255)",
                         "via-blue-50",
-                        "background-color: #EFF6FF;",
-                        ""
+                        "background-color: #EFF6FF;"
                     ],
                     [
                         "rgb(219, 234, 254)",
                         "via-blue-100",
-                        "background-color: #DBEAFE;",
-                        ""
+                        "background-color: #DBEAFE;"
                     ],
                     [
                         "rgb(191, 219, 254)",
                         "via-blue-200",
-                        "background-color: #BFDBFE;",
-                        ""
+                        "background-color: #BFDBFE;"
                     ],
                     [
                         "rgb(147, 197, 253)",
                         "via-blue-300",
-                        "background-color: #93C5FD;",
-                        ""
+                        "background-color: #93C5FD;"
                     ],
                     [
                         "rgb(96, 165, 250)",
                         "via-blue-400",
-                        "background-color: #60A5FA;",
-                        ""
+                        "background-color: #60A5FA;"
                     ],
                     [
                         "rgb(59, 130, 246)",
                         "via-blue-500",
-                        "background-color: #3B82F6;",
-                        ""
+                        "background-color: #3B82F6;"
                     ],
                     [
                         "rgb(37, 99, 235)",
                         "via-blue-600",
-                        "background-color: #2563EB;",
-                        ""
+                        "background-color: #2563EB;"
                     ],
                     [
                         "rgb(29, 78, 216)",
                         "via-blue-700",
-                        "background-color: #1D4ED8;",
-                        ""
+                        "background-color: #1D4ED8;"
                     ],
                     [
                         "rgb(30, 64, 175)",
                         "via-blue-800",
-                        "background-color: #1E40AF;",
-                        ""
+                        "background-color: #1E40AF;"
                     ],
                     [
                         "rgb(30, 58, 138)",
                         "via-blue-900",
-                        "background-color: #1E3A8A;",
-                        ""
+                        "background-color: #1E3A8A;"
                     ],
                     [
                         "rgb(238, 242, 255)",
                         "via-indigo-50",
-                        "background-color: #EEF2FF;",
-                        ""
+                        "background-color: #EEF2FF;"
                     ],
                     [
                         "rgb(224, 231, 255)",
                         "via-indigo-100",
-                        "background-color: #E0E7FF;",
-                        ""
+                        "background-color: #E0E7FF;"
                     ],
                     [
                         "rgb(199, 210, 254)",
                         "via-indigo-200",
-                        "background-color: #C7D2FE;",
-                        ""
+                        "background-color: #C7D2FE;"
                     ],
                     [
                         "rgb(165, 180, 252)",
                         "via-indigo-300",
-                        "background-color: #A5B4FC;",
-                        ""
+                        "background-color: #A5B4FC;"
                     ],
                     [
                         "rgb(129, 140, 248)",
                         "via-indigo-400",
-                        "background-color: #818CF8;",
-                        ""
+                        "background-color: #818CF8;"
                     ],
                     [
                         "rgb(99, 102, 241)",
                         "via-indigo-500",
-                        "background-color: #6366F1;",
-                        ""
+                        "background-color: #6366F1;"
                     ],
                     [
                         "rgb(79, 70, 229)",
                         "via-indigo-600",
-                        "background-color: #4F46E5;",
-                        ""
+                        "background-color: #4F46E5;"
                     ],
                     [
                         "rgb(67, 56, 202)",
                         "via-indigo-700",
-                        "background-color: #4338CA;",
-                        ""
+                        "background-color: #4338CA;"
                     ],
                     [
                         "rgb(55, 48, 163)",
                         "via-indigo-800",
-                        "background-color: #3730A3;",
-                        ""
+                        "background-color: #3730A3;"
                     ],
                     [
                         "rgb(49, 46, 129)",
                         "via-indigo-900",
-                        "background-color: #312E81;",
-                        ""
+                        "background-color: #312E81;"
                     ],
                     [
                         "rgb(245, 243, 255)",
                         "via-purple-50",
-                        "background-color: #F5F3FF;",
-                        ""
+                        "background-color: #F5F3FF;"
                     ],
                     [
                         "rgb(237, 233, 254)",
                         "via-purple-100",
-                        "background-color: #EDE9FE;",
-                        ""
+                        "background-color: #EDE9FE;"
                     ],
                     [
                         "rgb(221, 214, 254)",
                         "via-purple-200",
-                        "background-color: #DDD6FE;",
-                        ""
+                        "background-color: #DDD6FE;"
                     ],
                     [
                         "rgb(196, 181, 253)",
                         "via-purple-300",
-                        "background-color: #C4B5FD;",
-                        ""
+                        "background-color: #C4B5FD;"
                     ],
                     [
                         "rgb(167, 139, 250)",
                         "via-purple-400",
-                        "background-color: #A78BFA;",
-                        ""
+                        "background-color: #A78BFA;"
                     ],
                     [
                         "rgb(139, 92, 246)",
                         "via-purple-500",
-                        "background-color: #8B5CF6;",
-                        ""
+                        "background-color: #8B5CF6;"
                     ],
                     [
                         "rgb(124, 58, 237)",
                         "via-purple-600",
-                        "background-color: #7C3AED;",
-                        ""
+                        "background-color: #7C3AED;"
                     ],
                     [
                         "rgb(109, 40, 217)",
                         "via-purple-700",
-                        "background-color: #6D28D9;",
-                        ""
+                        "background-color: #6D28D9;"
                     ],
                     [
                         "rgb(91, 33, 182)",
                         "via-purple-800",
-                        "background-color: #5B21B6;",
-                        ""
+                        "background-color: #5B21B6;"
                     ],
                     [
                         "rgb(76, 29, 149)",
                         "via-purple-900",
-                        "background-color: #4C1D95;",
-                        ""
+                        "background-color: #4C1D95;"
                     ],
                     [
                         "rgb(253, 242, 248)",
                         "via-pink-50",
-                        "background-color: #FDF2F8;",
-                        ""
+                        "background-color: #FDF2F8;"
                     ],
                     [
                         "rgb(252, 231, 243)",
                         "via-pink-100",
-                        "background-color: #FCE7F3;",
-                        ""
+                        "background-color: #FCE7F3;"
                     ],
                     [
                         "rgb(251, 207, 232)",
                         "via-pink-200",
-                        "background-color: #FBCFE8;",
-                        ""
+                        "background-color: #FBCFE8;"
                     ],
                     [
                         "rgb(249, 168, 212)",
                         "via-pink-300",
-                        "background-color: #F9A8D4;",
-                        ""
+                        "background-color: #F9A8D4;"
                     ],
                     [
                         "rgb(244, 114, 182)",
                         "via-pink-400",
-                        "background-color: #F472B6;",
-                        ""
+                        "background-color: #F472B6;"
                     ],
                     [
                         "rgb(236, 72, 153)",
                         "via-pink-500",
-                        "background-color: #EC4899;",
-                        ""
+                        "background-color: #EC4899;"
                     ],
                     [
                         "rgb(219, 39, 119)",
                         "via-pink-600",
-                        "background-color: #DB2777;",
-                        ""
+                        "background-color: #DB2777;"
                     ],
                     [
                         "rgb(190, 24, 93)",
                         "via-pink-700",
-                        "background-color: #BE185D;",
-                        ""
+                        "background-color: #BE185D;"
                     ],
                     [
                         "rgb(157, 23, 77)",
                         "via-pink-800",
-                        "background-color: #9D174D;",
-                        ""
+                        "background-color: #9D174D;"
                     ],
                     [
                         "rgb(131, 24, 67)",
                         "via-pink-900",
-                        "background-color: #831843;",
-                        ""
+                        "background-color: #831843;"
                     ],
                     [
                         "transparent",
                         "to-transparent",
-                        "background-color: transparent;",
-                        ""
+                        "background-color: transparent;"
                     ],
                     [
                         "current color",
                         "to-current",
-                        "background-color: currentColor;",
-                        ""
+                        "background-color: currentColor;"
                     ],
                     [
                         "rgb(0, 0, 0)",
                         "to-black",
-                        "background-color: #000000;",
-                        ""
+                        "background-color: #000000;"
                     ],
                     [
                         "rgb(255, 255, 255)",
                         "to-white",
-                        "background-color: #ffffff;",
-                        ""
+                        "background-color: #ffffff;"
                     ],
                     [
                         "rgb(249, 250, 251)",
                         "to-gray-50",
-                        "background-color: #F9FAFB;",
-                        ""
+                        "background-color: #F9FAFB;"
                     ],
                     [
                         "rgb(243, 244, 246)",
                         "to-gray-100",
-                        "background-color: #F3F4F6;",
-                        ""
+                        "background-color: #F3F4F6;"
                     ],
                     [
                         "rgb(229, 231, 235)",
                         "to-gray-200",
-                        "background-color: #E5E7EB;",
-                        ""
+                        "background-color: #E5E7EB;"
                     ],
                     [
                         "rgb(209, 213, 219)",
                         "to-gray-300",
-                        "background-color: #D1D5DB;",
-                        ""
+                        "background-color: #D1D5DB;"
                     ],
                     [
                         "rgb(156, 163, 175)",
                         "to-gray-400",
-                        "background-color: #9CA3AF;",
-                        ""
+                        "background-color: #9CA3AF;"
                     ],
                     [
                         "rgb(107, 114, 128)",
                         "to-gray-500",
-                        "background-color: #6B7280;",
-                        ""
+                        "background-color: #6B7280;"
                     ],
                     [
                         "rgb(75, 85, 99)",
                         "to-gray-600",
-                        "background-color: #6B7280;",
-                        ""
+                        "background-color: #6B7280;"
                     ],
                     [
                         "rgb(55, 65, 81)",
                         "to-gray-700",
-                        "background-color: #374151;",
-                        ""
+                        "background-color: #374151;"
                     ],
                     [
                         "rgb(31, 41, 55)",
                         "to-gray-800",
-                        "background-color: #1F2937;",
-                        ""
+                        "background-color: #1F2937;"
                     ],
                     [
                         "rgb(17, 24, 39)",
                         "to-gray-900",
-                        "background-color: #111827;",
-                        ""
+                        "background-color: #111827;"
                     ],
                     [
                         "rgb(254, 242, 242)",
                         "to-red-50",
-                        "background-color: #FEF2F2;",
-                        ""
+                        "background-color: #FEF2F2;"
                     ],
                     [
                         "rgb(254, 226, 226)",
                         "to-red-100",
-                        "background-color: #FEE2E2;",
-                        ""
+                        "background-color: #FEE2E2;"
                     ],
                     [
                         "rgb(254, 202, 202)",
                         "to-red-200",
-                        "background-color: #FECACA;",
-                        ""
+                        "background-color: #FECACA;"
                     ],
                     [
                         "rgb(252, 165, 165)",
                         "to-red-300",
-                        "background-color: #FCA5A5;",
-                        ""
+                        "background-color: #FCA5A5;"
                     ],
                     [
                         "rgb(248, 113, 113)",
                         "to-red-400",
-                        "background-color: #F87171;",
-                        ""
+                        "background-color: #F87171;"
                     ],
                     [
                         "rgb(239, 68, 68)",
                         "to-red-500",
-                        "background-color: #EF4444;",
-                        ""
+                        "background-color: #EF4444;"
                     ],
                     [
                         "rgb(220, 38, 38)",
                         "to-red-600",
-                        "background-color: #DC2626;",
-                        ""
+                        "background-color: #DC2626;"
                     ],
                     [
                         "rgb(185, 28, 28)",
                         "to-red-700",
-                        "background-color: #B91C1C;",
-                        ""
+                        "background-color: #B91C1C;"
                     ],
                     [
                         "rgb(153, 27, 27)",
                         "to-red-800",
-                        "background-color: #991B1B;",
-                        ""
+                        "background-color: #991B1B;"
                     ],
                     [
                         "rgb(127, 29, 29)",
                         "to-red-900",
-                        "background-color: #7F1D1D;",
-                        ""
+                        "background-color: #7F1D1D;"
                     ],
                     [
                         "rgb(255, 251, 235)",
                         "to-yellow-50",
-                        "background-color: #FFFBEB;",
-                        ""
+                        "background-color: #FFFBEB;"
                     ],
                     [
                         "rgb(254, 243, 199)",
                         "to-yellow-100",
-                        "background-color: #FEF3C7;",
-                        ""
+                        "background-color: #FEF3C7;"
                     ],
                     [
                         "rgb(253, 230, 138)",
                         "to-yellow-200",
-                        "background-color: #FDE68A;",
-                        ""
+                        "background-color: #FDE68A;"
                     ],
                     [
                         "rgb(252, 211, 77)",
                         "to-yellow-300",
-                        "background-color: #FCD34D;",
-                        ""
+                        "background-color: #FCD34D;"
                     ],
                     [
                         "rgb(251, 191, 36)",
                         "to-yellow-400",
-                        "background-color: #FBBF24;",
-                        ""
+                        "background-color: #FBBF24;"
                     ],
                     [
                         "rgb(245, 158, 11)",
                         "to-yellow-500",
-                        "background-color: #F59E0B;",
-                        ""
+                        "background-color: #F59E0B;"
                     ],
                     [
                         "rgb(217, 119, 6)",
                         "to-yellow-600",
-                        "background-color: #D97706;",
-                        ""
+                        "background-color: #D97706;"
                     ],
                     [
                         "rgb(180, 83, 9)",
                         "to-yellow-700",
-                        "background-color: #B45309;",
-                        ""
+                        "background-color: #B45309;"
                     ],
                     [
                         "rgb(146, 64, 14)",
                         "to-yellow-800",
-                        "background-color: #92400E;",
-                        ""
+                        "background-color: #92400E;"
                     ],
                     [
                         "rgb(120, 53, 15)",
                         "to-yellow-900",
-                        "background-color: #78350F;",
-                        ""
+                        "background-color: #78350F;"
                     ],
                     [
                         "rgb(236, 253, 245)",
                         "to-green-50",
-                        "background-color: #ECFDF5;",
-                        ""
+                        "background-color: #ECFDF5;"
                     ],
                     [
                         "rgb(209, 250, 229)",
                         "to-green-100",
-                        "background-color: #D1FAE5;",
-                        ""
+                        "background-color: #D1FAE5;"
                     ],
                     [
                         "rgb(167, 243, 208)",
                         "to-green-200",
-                        "background-color: #A7F3D0;",
-                        ""
+                        "background-color: #A7F3D0;"
                     ],
                     [
                         "rgb(110, 231, 183)",
                         "to-green-300",
-                        "background-color: #6EE7B7;",
-                        ""
+                        "background-color: #6EE7B7;"
                     ],
                     [
                         "rgb(52, 211, 153)",
                         "to-green-400",
-                        "background-color: #34D399;",
-                        ""
+                        "background-color: #34D399;"
                     ],
                     [
                         "rgb(16, 185, 129)",
                         "to-green-500",
-                        "background-color: #10B981;",
-                        ""
+                        "background-color: #10B981;"
                     ],
                     [
                         "rgb(5, 150, 105)",
                         "to-green-600",
-                        "background-color: #059669;",
-                        ""
+                        "background-color: #059669;"
                     ],
                     [
                         "rgb(4, 120, 87)",
                         "to-green-700",
-                        "background-color: #047857;",
-                        ""
+                        "background-color: #047857;"
                     ],
                     [
                         "rgb(6, 95, 70)",
                         "to-green-800",
-                        "background-color: #065F46;",
-                        ""
+                        "background-color: #065F46;"
                     ],
                     [
                         "rgb(6, 78, 59)",
                         "to-green-900",
-                        "background-color: #064E3B;",
-                        ""
+                        "background-color: #064E3B;"
                     ],
                     [
                         "rgb(239, 246, 255)",
                         "to-blue-50",
-                        "background-color: #EFF6FF;",
-                        ""
+                        "background-color: #EFF6FF;"
                     ],
                     [
                         "rgb(219, 234, 254)",
                         "to-blue-100",
-                        "background-color: #DBEAFE;",
-                        ""
+                        "background-color: #DBEAFE;"
                     ],
                     [
                         "rgb(191, 219, 254)",
                         "to-blue-200",
-                        "background-color: #BFDBFE;",
-                        ""
+                        "background-color: #BFDBFE;"
                     ],
                     [
                         "rgb(147, 197, 253)",
                         "to-blue-300",
-                        "background-color: #93C5FD;",
-                        ""
+                        "background-color: #93C5FD;"
                     ],
                     [
                         "rgb(96, 165, 250)",
                         "to-blue-400",
-                        "background-color: #60A5FA;",
-                        ""
+                        "background-color: #60A5FA;"
                     ],
                     [
                         "rgb(59, 130, 246)",
                         "to-blue-500",
-                        "background-color: #3B82F6;",
-                        ""
+                        "background-color: #3B82F6;"
                     ],
                     [
                         "rgb(37, 99, 235)",
                         "to-blue-600",
-                        "background-color: #2563EB;",
-                        ""
+                        "background-color: #2563EB;"
                     ],
                     [
                         "rgb(29, 78, 216)",
                         "to-blue-700",
-                        "background-color: #1D4ED8;",
-                        ""
+                        "background-color: #1D4ED8;"
                     ],
                     [
                         "rgb(30, 64, 175)",
                         "to-blue-800",
-                        "background-color: #1E40AF;",
-                        ""
+                        "background-color: #1E40AF;"
                     ],
                     [
                         "rgb(30, 58, 138)",
                         "to-blue-900",
-                        "background-color: #1E3A8A;",
-                        ""
+                        "background-color: #1E3A8A;"
                     ],
                     [
                         "rgb(238, 242, 255)",
                         "to-indigo-50",
-                        "background-color: #EEF2FF;",
-                        ""
+                        "background-color: #EEF2FF;"
                     ],
                     [
                         "rgb(224, 231, 255)",
                         "to-indigo-100",
-                        "background-color: #E0E7FF;",
-                        ""
+                        "background-color: #E0E7FF;"
                     ],
                     [
                         "rgb(199, 210, 254)",
                         "to-indigo-200",
-                        "background-color: #C7D2FE;",
-                        ""
+                        "background-color: #C7D2FE;"
                     ],
                     [
                         "rgb(165, 180, 252)",
                         "to-indigo-300",
-                        "background-color: #A5B4FC;",
-                        ""
+                        "background-color: #A5B4FC;"
                     ],
                     [
                         "rgb(129, 140, 248)",
                         "to-indigo-400",
-                        "background-color: #818CF8;",
-                        ""
+                        "background-color: #818CF8;"
                     ],
                     [
                         "rgb(99, 102, 241)",
                         "to-indigo-500",
-                        "background-color: #6366F1;",
-                        ""
+                        "background-color: #6366F1;"
                     ],
                     [
                         "rgb(79, 70, 229)",
                         "to-indigo-600",
-                        "background-color: #4F46E5;",
-                        ""
+                        "background-color: #4F46E5;"
                     ],
                     [
                         "rgb(67, 56, 202)",
                         "to-indigo-700",
-                        "background-color: #4338CA;",
-                        ""
+                        "background-color: #4338CA;"
                     ],
                     [
                         "rgb(55, 48, 163)",
                         "to-indigo-800",
-                        "background-color: #3730A3;",
-                        ""
+                        "background-color: #3730A3;"
                     ],
                     [
                         "rgb(49, 46, 129)",
                         "to-indigo-900",
-                        "background-color: #312E81;",
-                        ""
+                        "background-color: #312E81;"
                     ],
                     [
                         "rgb(245, 243, 255)",
                         "to-purple-50",
-                        "background-color: #F5F3FF;",
-                        ""
+                        "background-color: #F5F3FF;"
                     ],
                     [
                         "rgb(237, 233, 254)",
                         "to-purple-100",
-                        "background-color: #EDE9FE;",
-                        ""
+                        "background-color: #EDE9FE;"
                     ],
                     [
                         "rgb(221, 214, 254)",
                         "to-purple-200",
-                        "background-color: #DDD6FE;",
-                        ""
+                        "background-color: #DDD6FE;"
                     ],
                     [
                         "rgb(196, 181, 253)",
                         "to-purple-300",
-                        "background-color: #C4B5FD;",
-                        ""
+                        "background-color: #C4B5FD;"
                     ],
                     [
                         "rgb(167, 139, 250)",
                         "to-purple-400",
-                        "background-color: #A78BFA;",
-                        ""
+                        "background-color: #A78BFA;"
                     ],
                     [
                         "rgb(139, 92, 246)",
                         "to-purple-500",
-                        "background-color: #8B5CF6;",
-                        ""
+                        "background-color: #8B5CF6;"
                     ],
                     [
                         "rgb(124, 58, 237)",
                         "to-purple-600",
-                        "background-color: #7C3AED;",
-                        ""
+                        "background-color: #7C3AED;"
                     ],
                     [
                         "rgb(109, 40, 217)",
                         "to-purple-700",
-                        "background-color: #6D28D9;",
-                        ""
+                        "background-color: #6D28D9;"
                     ],
                     [
                         "rgb(91, 33, 182)",
                         "to-purple-800",
-                        "background-color: #5B21B6;",
-                        ""
+                        "background-color: #5B21B6;"
                     ],
                     [
                         "rgb(76, 29, 149)",
                         "to-purple-900",
-                        "background-color: #4C1D95;",
-                        ""
+                        "background-color: #4C1D95;"
                     ],
                     [
                         "rgb(253, 242, 248)",
                         "to-pink-50",
-                        "background-color: #FDF2F8;",
-                        ""
+                        "background-color: #FDF2F8;"
                     ],
                     [
                         "rgb(252, 231, 243)",
                         "to-pink-100",
-                        "background-color: #FCE7F3;",
-                        ""
+                        "background-color: #FCE7F3;"
                     ],
                     [
                         "rgb(251, 207, 232)",
                         "to-pink-200",
-                        "background-color: #FBCFE8;",
-                        ""
+                        "background-color: #FBCFE8;"
                     ],
                     [
                         "rgb(249, 168, 212)",
                         "to-pink-300",
-                        "background-color: #F9A8D4;",
-                        ""
+                        "background-color: #F9A8D4;"
                     ],
                     [
                         "rgb(244, 114, 182)",
                         "to-pink-400",
-                        "background-color: #F472B6;",
-                        ""
+                        "background-color: #F472B6;"
                     ],
                     [
                         "rgb(236, 72, 153)",
                         "to-pink-500",
-                        "background-color: #EC4899;",
-                        ""
+                        "background-color: #EC4899;"
                     ],
                     [
                         "rgb(219, 39, 119)",
                         "to-pink-600",
-                        "background-color: #DB2777;",
-                        ""
+                        "background-color: #DB2777;"
                     ],
                     [
                         "rgb(190, 24, 93)",
                         "to-pink-700",
-                        "background-color: #BE185D;",
-                        ""
+                        "background-color: #BE185D;"
                     ],
                     [
                         "rgb(157, 23, 77)",
                         "to-pink-800",
-                        "background-color: #9D174D;",
-                        ""
+                        "background-color: #9D174D;"
                     ],
                     [
                         "rgb(131, 24, 67)",
                         "to-pink-900",
-                        "background-color: #831843;",
-                        ""
+                        "background-color: #831843;"
                     ]
                 ]
             }
@@ -17702,38 +15490,31 @@
                 "table": [
                     [
                         "transition",
-                        "transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
-                        ""
+                        "transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;"
                     ],
                     [
                         "transition-none",
-                        "transition-property: none;",
-                        ""
+                        "transition-property: none;"
                     ],
                     [
                         "transition-all",
-                        "transition-property: all;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
-                        ""
+                        "transition-property: all;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;"
                     ],
                     [
                         "transition-colors",
-                        "transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
-                        ""
+                        "transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;"
                     ],
                     [
                         "transition-opacity",
-                        "transition-property: opacity;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
-                        ""
+                        "transition-property: opacity;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;"
                     ],
                     [
                         "transition-shadow",
-                        "transition-property: box-shadow;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
-                        ""
+                        "transition-property: box-shadow;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;"
                     ],
                     [
                         "transition-transform",
-                        "transition-property: transform;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;",
-                        ""
+                        "transition-property: transform;\ntransition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);\ntransition-duration: 300ms;"
                     ]
                 ]
             },
@@ -17744,43 +15525,35 @@
                 "table": [
                     [
                         "duration-75",
-                        "transition-duration: 75ms;",
-                        ""
+                        "transition-duration: 75ms;"
                     ],
                     [
                         "duration-100",
-                        "transition-duration: 100ms;",
-                        ""
+                        "transition-duration: 100ms;"
                     ],
                     [
                         "duration-150",
-                        "transition-duration: 150ms;",
-                        ""
+                        "transition-duration: 150ms;"
                     ],
                     [
                         "duration-200",
-                        "transition-duration: 200ms;",
-                        ""
+                        "transition-duration: 200ms;"
                     ],
                     [
                         "duration-300",
-                        "transition-duration: 300ms;",
-                        ""
+                        "transition-duration: 300ms;"
                     ],
                     [
                         "duration-500",
-                        "transition-duration: 500ms;",
-                        ""
+                        "transition-duration: 500ms;"
                     ],
                     [
                         "duration-700",
-                        "transition-duration: 700ms;",
-                        ""
+                        "transition-duration: 700ms;"
                     ],
                     [
                         "duration-1000",
-                        "transition-duration: 1000ms;",
-                        ""
+                        "transition-duration: 1000ms;"
                     ]
                 ]
             },
@@ -17791,23 +15564,19 @@
                 "table": [
                     [
                         "ease-linear",
-                        "transition-timing-function: linear;",
-                        ""
+                        "transition-timing-function: linear;"
                     ],
                     [
                         "ease-in",
-                        "transition-timing-function: cubic-bezier(0.4, 0, 1, 1);",
-                        ""
+                        "transition-timing-function: cubic-bezier(0.4, 0, 1, 1);"
                     ],
                     [
                         "ease-out",
-                        "transition-timing-function: cubic-bezier(0, 0, 0.2, 1);",
-                        ""
+                        "transition-timing-function: cubic-bezier(0, 0, 0.2, 1);"
                     ],
                     [
                         "ease-in-out",
-                        "transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);",
-                        ""
+                        "transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);"
                     ]
                 ]
             },
@@ -17818,43 +15587,35 @@
                 "table": [
                     [
                         "delay-75",
-                        "transition-delay: 75ms;",
-                        ""
+                        "transition-delay: 75ms;"
                     ],
                     [
                         "delay-100",
-                        "transition-delay: 100ms;",
-                        ""
+                        "transition-delay: 100ms;"
                     ],
                     [
                         "delay-150",
-                        "transition-delay: 150ms;",
-                        ""
+                        "transition-delay: 150ms;"
                     ],
                     [
                         "delay-200",
-                        "transition-delay: 200ms;",
-                        ""
+                        "transition-delay: 200ms;"
                     ],
                     [
                         "delay-300",
-                        "transition-delay: 300ms;",
-                        ""
+                        "transition-delay: 300ms;"
                     ],
                     [
                         "delay-500",
-                        "transition-delay: 500ms;",
-                        ""
+                        "transition-delay: 500ms;"
                     ],
                     [
                         "delay-700",
-                        "transition-delay: 700ms;",
-                        ""
+                        "transition-delay: 700ms;"
                     ],
                     [
                         "delay-1000",
-                        "transition-delay: 1000ms;",
-                        ""
+                        "transition-delay: 1000ms;"
                     ]
                 ]
             },
@@ -17865,28 +15626,23 @@
                 "table": [
                     [
                         "animate-none",
-                        "animation: none;",
-                        ""
+                        "animation: none;"
                     ],
                     [
                         "animate-spin",
-                        "animation: spin 1s linear infinite;\n\n@keyframes spin {\n  from {\n    transform: rotate(0deg);\n  }\n  to {\n    transform: rotate(360deg);\n  }\n}",
-                        ""
+                        "animation: spin 1s linear infinite;\n\n@keyframes spin {\n  from {\n    transform: rotate(0deg);\n  }\n  to {\n    transform: rotate(360deg);\n  }\n}"
                     ],
                     [
                         "animate-ping",
-                        "animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;\n\n@keyframes ping {\n  75%, 100% {\n    transform: scale(2);\n    opacity: 0;\n  }\n}",
-                        ""
+                        "animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;\n\n@keyframes ping {\n  75%, 100% {\n    transform: scale(2);\n    opacity: 0;\n  }\n}"
                     ],
                     [
                         "animate-pulse",
-                        "animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;\n\n@keyframes pulse {\n  0%, 100% {\n    opacity: 1;\n  }\n  50% {\n    opacity: .5;\n  }\n}",
-                        ""
+                        "animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;\n\n@keyframes pulse {\n  0%, 100% {\n    opacity: 1;\n  }\n  50% {\n    opacity: .5;\n  }\n}"
                     ],
                     [
                         "animate-bounce",
-                        "animation: animation: bounce 1s infinite;\n\n@keyframes bounce {\n  0%, 100% {\n    transform: translateY(-25%);\n    animationTimingFunction: cubic-bezier(0.8, 0, 1, 1);\n  }\n  50% {\n    transform: translateY(0);\n    animationTimingFunction: cubic-bezier(0, 0, 0.2, 1);\n  }\n}",
-                        ""
+                        "animation: animation: bounce 1s infinite;\n\n@keyframes bounce {\n  0%, 100% {\n    transform: translateY(-25%);\n    animationTimingFunction: cubic-bezier(0.8, 0, 1, 1);\n  }\n  50% {\n    transform: translateY(0);\n    animationTimingFunction: cubic-bezier(0, 0, 0.2, 1);\n  }\n}"
                     ]
                 ]
             }
@@ -17895,7 +15651,7 @@
     {
         "title": "Transforms",
         "content": [
-            
+
             {
                 "title": "Scale",
                 "docs": "https://tailwindcss.com/docs/scale",
@@ -17903,153 +15659,123 @@
                 "table": [
                     [
                         "scale-0",
-                        "--transform-scale-x: 0;\n--transform-scale-y: 0;",
-                        ""
+                        "--transform-scale-x: 0;\n--transform-scale-y: 0;"
                     ],
                     [
                         "scale-50",
-                        "--transform-scale-x: .5;\n--transform-scale-y: .5;",
-                        ""
+                        "--transform-scale-x: .5;\n--transform-scale-y: .5;"
                     ],
                     [
                         "scale-75",
-                        "--transform-scale-x: .75;\n--transform-scale-y: .75;",
-                        ""
+                        "--transform-scale-x: .75;\n--transform-scale-y: .75;"
                     ],
                     [
                         "scale-90",
-                        "--transform-scale-x: .9;\n--transform-scale-y: .9;",
-                        ""
+                        "--transform-scale-x: .9;\n--transform-scale-y: .9;"
                     ],
                     [
                         "scale-95",
-                        "--transform-scale-x: .95;\n--transform-scale-y: .95;",
-                        ""
+                        "--transform-scale-x: .95;\n--transform-scale-y: .95;"
                     ],
                     [
                         "scale-100",
-                        "--transform-scale-x: 1;\n--transform-scale-y: 1;",
-                        ""
+                        "--transform-scale-x: 1;\n--transform-scale-y: 1;"
                     ],
                     [
                         "scale-105",
-                        "--transform-scale-x: 1.05;\n--transform-scale-y: 1.05;",
-                        ""
+                        "--transform-scale-x: 1.05;\n--transform-scale-y: 1.05;"
                     ],
                     [
                         "scale-110",
-                        "--transform-scale-x: 1.1;\n--transform-scale-y: 1.1;",
-                        ""
+                        "--transform-scale-x: 1.1;\n--transform-scale-y: 1.1;"
                     ],
                     [
                         "scale-125",
-                        "--transform-scale-x: 1.25;\n--transform-scale-y: 1.25;",
-                        ""
+                        "--transform-scale-x: 1.25;\n--transform-scale-y: 1.25;"
                     ],
                     [
                         "scale-150",
-                        "--transform-scale-x: 1.5;\n--transform-scale-y: 1.5;",
-                        ""
+                        "--transform-scale-x: 1.5;\n--transform-scale-y: 1.5;"
                     ],
                     [
                         "scale-x-0",
-                        "--transform-scale-x: 0;",
-                        ""
+                        "--transform-scale-x: 0;"
                     ],
                     [
                         "scale-x-50",
-                        "--transform-scale-x: .5;",
-                        ""
+                        "--transform-scale-x: .5;"
                     ],
                     [
                         "scale-x-75",
-                        "--transform-scale-x: .75;",
-                        ""
+                        "--transform-scale-x: .75;"
                     ],
                     [
                         "scale-x-90",
-                        "--transform-scale-x: .9;",
-                        ""
+                        "--transform-scale-x: .9;"
                     ],
                     [
                         "scale-x-95",
-                        "--transform-scale-x: .95;",
-                        ""
+                        "--transform-scale-x: .95;"
                     ],
                     [
                         "scale-x-100",
-                        "--transform-scale-x: 1;",
-                        ""
+                        "--transform-scale-x: 1;"
                     ],
                     [
                         "scale-x-105",
-                        "--transform-scale-x: 1.05;",
-                        ""
+                        "--transform-scale-x: 1.05;"
                     ],
                     [
                         "scale-x-110",
-                        "--transform-scale-x: 1.1;",
-                        ""
+                        "--transform-scale-x: 1.1;"
                     ],
                     [
                         "scale-x-125",
-                        "--transform-scale-x: 1.25;",
-                        ""
+                        "--transform-scale-x: 1.25;"
                     ],
                     [
                         "scale-x-150",
-                        "--transform-scale-x: 1.5;",
-                        ""
+                        "--transform-scale-x: 1.5;"
                     ],
                     [
                         "scale-y-0",
-                        "--transform-scale-y: 0;",
-                        ""
+                        "--transform-scale-y: 0;"
                     ],
                     [
                         "scale-y-50",
-                        "--transform-scale-y: .5;",
-                        ""
+                        "--transform-scale-y: .5;"
                     ],
                     [
                         "scale-y-75",
-                        "--transform-scale-y: .75;",
-                        ""
+                        "--transform-scale-y: .75;"
                     ],
                     [
                         "scale-y-90",
-                        "--transform-scale-y: .9;",
-                        ""
+                        "--transform-scale-y: .9;"
                     ],
                     [
                         "scale-y-95",
-                        "--transform-scale-y: .95;",
-                        ""
+                        "--transform-scale-y: .95;"
                     ],
                     [
                         "scale-y-100",
-                        "--transform-scale-y: 1;",
-                        ""
+                        "--transform-scale-y: 1;"
                     ],
                     [
                         "scale-y-105",
-                        "--transform-scale-y: 1.05;",
-                        ""
+                        "--transform-scale-y: 1.05;"
                     ],
                     [
                         "scale-y-110",
-                        "--transform-scale-y: 1.1;",
-                        ""
+                        "--transform-scale-y: 1.1;"
                     ],
                     [
                         "scale-y-125",
-                        "--transform-scale-y: 1.25;",
-                        ""
+                        "--transform-scale-y: 1.25;"
                     ],
                     [
                         "scale-y-150",
-                        "--transform-scale-y: 1.5;",
-                        ""
+                        "--transform-scale-y: 1.5;"
                     ]
                 ]
             },
@@ -18060,48 +15786,39 @@
                 "table": [
                     [
                         "rotate-0",
-                        "--transform-rotate: 0;",
-                        ""
+                        "--transform-rotate: 0;"
                     ],
                     [
                         "rotate-1",
-                        "--transform-rotate: 1deg;",
-                        ""
+                        "--transform-rotate: 1deg;"
                     ],
                     [
                         "rotate-2",
-                        "--transform-rotate: 2deg;",
-                        ""
+                        "--transform-rotate: 2deg;"
                     ],
                     [
                         "rotate-3",
-                        "--transform-rotate: 3deg;",
-                        ""
+                        "--transform-rotate: 3deg;"
                     ],
                     [
                         "rotate-6",
-                        "--transform-rotate: 6deg;",
-                        ""
+                        "--transform-rotate: 6deg;"
                     ],
                     [
                         "rotate-12",
-                        "--transform-rotate: 12deg;",
-                        ""
+                        "--transform-rotate: 12deg;"
                     ],
                     [
                         "rotate-45",
-                        "--transform-rotate: 45deg;",
-                        ""
+                        "--transform-rotate: 45deg;"
                     ],
                     [
                         "rotate-90",
-                        "--transform-rotate: 90deg;",
-                        ""
+                        "--transform-rotate: 90deg;"
                     ],
                     [
                         "rotate-180",
-                        "--transform-rotate: 180deg;",
-                        ""
+                        "--transform-rotate: 180deg;"
                     ]
                 ]
             },
@@ -18112,8 +15829,7 @@
                 "table": [
                     [
                         "translate-x-0",
-                        "--transform-translate-x: 0;",
-                        ""
+                        "--transform-translate-x: 0;"
                     ],
                     [
                         "translate-x-0.5",
@@ -18282,48 +15998,39 @@
                     ],
                     [
                         "translate-x-px",
-                        "--transform-translate-x: 1px;",
-                        ""
+                        "--transform-translate-x: 1px;"
                     ],
                     [
                         "translate-x-1/2",
-                        "--transform-translate-x: 50%;",
-                        ""
+                        "--transform-translate-x: 50%;"
                     ],
                     [
                         "translate-x-1/3",
-                        "--transform-translate-x: 33.333333%;",
-                        ""
+                        "--transform-translate-x: 33.333333%;"
                     ],
                     [
                         "translate-x-2/3",
-                        "--transform-translate-x: 66.6666666%;",
-                        ""
+                        "--transform-translate-x: 66.6666666%;"
                     ],
                     [
                         "translate-x-1/4",
-                        "--transform-translate-x: 25%;",
-                        ""
+                        "--transform-translate-x: 25%;"
                     ],
                     [
                         "translate-x-2/4",
-                        "--transform-translate-x: 50%;",
-                        ""
+                        "--transform-translate-x: 50%;"
                     ],
                     [
                         "translate-x-3/4",
-                        "--transform-translate-x: 75%;",
-                        ""
+                        "--transform-translate-x: 75%;"
                     ],
                     [
                         "translate-x-full",
-                        "--transform-translate-x: 100%;",
-                        ""
+                        "--transform-translate-x: 100%;"
                     ],
                     [
                         "translate-y-0",
-                        "--transform-translate-y: 0;",
-                        ""
+                        "--transform-translate-y: 0;"
                     ],
                     [
                         "translate-y-0.5",
@@ -18492,43 +16199,35 @@
                     ],
                     [
                         "translate-y-px",
-                        "--transform-translate-y: 1px;",
-                        ""
+                        "--transform-translate-y: 1px;"
                     ],
                     [
                         "translate-y-1/2",
-                        "--transform-translate-y: 50%;",
-                        ""
+                        "--transform-translate-y: 50%;"
                     ],
                     [
                         "translate-y-1/3",
-                        "--transform-translate-y: 33.333333%;",
-                        ""
+                        "--transform-translate-y: 33.333333%;"
                     ],
                     [
                         "translate-y-2/3",
-                        "--transform-translate-y: 66.6666666%;",
-                        ""
+                        "--transform-translate-y: 66.6666666%;"
                     ],
                     [
                         "translate-y-1/4",
-                        "--transform-translate-y: 25%;",
-                        ""
+                        "--transform-translate-y: 25%;"
                     ],
                     [
                         "translate-y-2/4",
-                        "--transform-translate-y: 50%;",
-                        ""
+                        "--transform-translate-y: 50%;"
                     ],
                     [
                         "translate-y-3/4",
-                        "--transform-translate-y: 75%;",
-                        ""
+                        "--transform-translate-y: 75%;"
                     ],
                     [
                         "translate-y-full",
-                        "--transform-translate-y: 100%;",
-                        ""
+                        "--transform-translate-y: 100%;"
                     ]
                 ]
             },
@@ -18539,63 +16238,51 @@
                 "table": [
                     [
                         "skew-x-0",
-                        "--transform-skew-x: 0;",
-                        ""
+                        "--transform-skew-x: 0;"
                     ],
                     [
                         "skew-x-1",
-                        "--transform-skew-x: 1deg;",
-                        ""
+                        "--transform-skew-x: 1deg;"
                     ],
                     [
                         "skew-x-2",
-                        "--transform-skew-x: 2deg;",
-                        ""
+                        "--transform-skew-x: 2deg;"
                     ],
                     [
                         "skew-x-3",
-                        "--transform-skew-x: 3deg;",
-                        ""
+                        "--transform-skew-x: 3deg;"
                     ],
                     [
                         "skew-x-6",
-                        "--transform-skew-x: 6deg;",
-                        ""
+                        "--transform-skew-x: 6deg;"
                     ],
                     [
                         "skew-x-12",
-                        "--transform-skew-x: 12deg;",
-                        ""
+                        "--transform-skew-x: 12deg;"
                     ],
                     [
                         "skew-y-0",
-                        "--transform-skew-y: 0;",
-                        ""
+                        "--transform-skew-y: 0;"
                     ],
                     [
                         "skew-y-1",
-                        "--transform-skew-y: 1deg;",
-                        ""
+                        "--transform-skew-y: 1deg;"
                     ],
                     [
                         "skew-y-2",
-                        "--transform-skew-y: 2deg;",
-                        ""
+                        "--transform-skew-y: 2deg;"
                     ],
                     [
                         "skew-y-3",
-                        "--transform-skew-y: 3deg;",
-                        ""
+                        "--transform-skew-y: 3deg;"
                     ],
                     [
                         "skew-y-6",
-                        "--transform-skew-y: 6deg;",
-                        ""
+                        "--transform-skew-y: 6deg;"
                     ],
                     [
                         "skew-y-12",
-                        "--transform-skew-y: 12deg;",
-                        ""
+                        "--transform-skew-y: 12deg;"
                     ]
                 ]
             },
@@ -18606,48 +16293,39 @@
                 "table": [
                     [
                         "origin-center",
-                        "transform-origin: center;",
-                        ""
+                        "transform-origin: center;"
                     ],
                     [
                         "origin-top",
-                        "transform-origin: top;",
-                        ""
+                        "transform-origin: top;"
                     ],
                     [
                         "origin-top-right",
-                        "transform-origin: top right;",
-                        ""
+                        "transform-origin: top right;"
                     ],
                     [
                         "origin-right",
-                        "transform-origin: right;",
-                        ""
+                        "transform-origin: right;"
                     ],
                     [
                         "origin-bottom-right",
-                        "transform-origin: bottom right;",
-                        ""
+                        "transform-origin: bottom right;"
                     ],
                     [
                         "origin-bottom",
-                        "transform-origin: bottom;",
-                        ""
+                        "transform-origin: bottom;"
                     ],
                     [
                         "origin-bottom-left",
-                        "transform-origin: bottom left;",
-                        ""
+                        "transform-origin: bottom left;"
                     ],
                     [
                         "origin-left",
-                        "transform-origin: left;",
-                        ""
+                        "transform-origin: left;"
                     ],
                     [
                         "origin-top-left",
-                        "transform-origin: top left;",
-                        ""
+                        "transform-origin: top left;"
                     ]
                 ]
             }
@@ -18663,8 +16341,7 @@
                 "table": [
                     [
                         "appearance-none",
-                        "appearance: none;",
-                        ""
+                        "appearance: none;"
                     ]
                 ]
             },
@@ -18675,183 +16352,147 @@
                 "table": [
                     [
                         "cursor-auto",
-                        "cursor: auto;",
-                        ""
+                        "cursor: auto;"
                     ],
                     [
                         "cursor-default",
-                        "cursor: default;",
-                        ""
+                        "cursor: default;"
                     ],
                     [
                         "cursor-pointer",
-                        "cursor: pointer;",
-                        ""
+                        "cursor: pointer;"
                     ],
                     [
                         "cursor-wait",
-                        "cursor: wait;",
-                        ""
+                        "cursor: wait;"
                     ],
                     [
                         "cursor-text",
-                        "cursor: text;",
-                        ""
+                        "cursor: text;"
                     ],
                     [
                         "cursor-move",
-                        "cursor: move;",
-                        ""
+                        "cursor: move;"
                     ],
                     [
                         "cursor-help",
-                        "cursor: help;",
-                        ""
+                        "cursor: help;"
                     ],
                     [
                         "cursor-not-allowed",
-                        "cursor: not-allowed;",
-                        ""
+                        "cursor: not-allowed;"
                     ],
                     [
                         "cursor-none",
-                        "cursor: none;",
-                        ""
+                        "cursor: none;"
                     ],
                     [
                         "cursor-context-menu",
-                        "cursor: context-menu;",
-                        ""
+                        "cursor: context-menu;"
                     ],
                     [
                         "cursor-progress",
-                        "cursor: progress;",
-                        ""
+                        "cursor: progress;"
                     ],
                     [
                         "cursor-cell",
-                        "cursor: cell;",
-                        ""
+                        "cursor: cell;"
                     ],
                     [
                         "cursor-crosshair",
-                        "cursor: crosshair;",
-                        ""
+                        "cursor: crosshair;"
                     ],
                     [
                         "cursor-vertical-text",
-                        "cursor: vertical-text;",
-                        ""
+                        "cursor: vertical-text;"
                     ],
                     [
                         "cursor-alias",
-                        "cursor: alias;",
-                        ""
+                        "cursor: alias;"
                     ],
                     [
                         "cursor-copy",
-                        "cursor: copy;",
-                        ""
+                        "cursor: copy;"
                     ],
                     [
                         "cursor-no-drop",
-                        "cursor: no-drop;",
-                        ""
+                        "cursor: no-drop;"
                     ],
                     [
                         "cursor-grab",
-                        "cursor: grab;",
-                        ""
+                        "cursor: grab;"
                     ],
                     [
                         "cursor-grabbing",
-                        "cursor: grabbing;",
-                        ""
+                        "cursor: grabbing;"
                     ],
                     [
                         "cursor-all-scroll",
-                        "cursor: all-scroll;",
-                        ""
+                        "cursor: all-scroll;"
                     ],
                     [
                         "cursor-col-resize",
-                        "cursor: col-resize;",
-                        ""
+                        "cursor: col-resize;"
                     ],
                     [
                         "cursor-row-resize",
-                        "cursor: row-resize;",
-                        ""
+                        "cursor: row-resize;"
                     ],
                     [
                         "cursor-n-resize",
-                        "cursor: n-resize;",
-                        ""
+                        "cursor: n-resize;"
                     ],
                     [
                         "cursor-e-resize",
-                        "cursor: e-resize;",
-                        ""
+                        "cursor: e-resize;"
                     ],
                     [
                         "cursor-s-resize",
-                        "cursor: s-resize;",
-                        ""
+                        "cursor: s-resize;"
                     ],
                     [
                         "cursor-w-resize",
-                        "cursor: w-resize;",
-                        ""
+                        "cursor: w-resize;"
                     ],
                     [
                         "cursor-ne-resize",
-                        "cursor: ne-resize;",
-                        ""
+                        "cursor: ne-resize;"
                     ],
                     [
                         "cursor-nw-resize",
-                        "cursor: nw-resize;",
-                        ""
+                        "cursor: nw-resize;"
                     ],
                     [
                         "cursor-se-resize",
-                        "cursor: se-resize;",
-                        ""
+                        "cursor: se-resize;"
                     ],
                     [
                         "cursor-sw-resize",
-                        "cursor: sw-resize;",
-                        ""
+                        "cursor: sw-resize;"
                     ],
                     [
                         "cursor-ew-resize",
-                        "cursor: ew-resize;",
-                        ""
+                        "cursor: ew-resize;"
                     ],
                     [
                         "cursor-ns-resize",
-                        "cursor: ns-resize;",
-                        ""
+                        "cursor: ns-resize;"
                     ],
                     [
                         "cursor-nesw-resize",
-                        "cursor: nesw-resize;",
-                        ""
+                        "cursor: nesw-resize;"
                     ],
                     [
                         "cursor-nwse-resize",
-                        "cursor: nwse-resize;",
-                        ""
+                        "cursor: nwse-resize;"
                     ],
                     [
                         "cursor-zoom-in",
-                        "cursor: zoom-in;",
-                        ""
+                        "cursor: zoom-in;"
                     ],
                     [
                         "cursor-zoom-out",
-                        "cursor: zoom-out;",
-                        ""
+                        "cursor: zoom-out;"
                     ]
                 ]
             },
@@ -18862,13 +16503,11 @@
                 "table": [
                     [
                         "pointer-events-none",
-                        "pointer-events: none;",
-                        ""
+                        "pointer-events: none;"
                     ],
                     [
                         "pointer-events-auto",
-                        "pointer-events: auto;",
-                        ""
+                        "pointer-events: auto;"
                     ]
                 ]
             },
@@ -18879,23 +16518,19 @@
                 "table": [
                     [
                         "resize-none",
-                        "resize: none;",
-                        ""
+                        "resize: none;"
                     ],
                     [
                         "resize",
-                        "resize: both;",
-                        ""
+                        "resize: both;"
                     ],
                     [
                         "resize-y",
-                        "resize: vertical;",
-                        ""
+                        "resize: vertical;"
                     ],
                     [
                         "resize-x",
-                        "resize: horizontal;",
-                        ""
+                        "resize: horizontal;"
                     ]
                 ]
             },
@@ -18906,13 +16541,11 @@
                 "table": [
                     [
                         "scroll-auto",
-                        "scroll-behavior: auto;",
-                        ""
+                        "scroll-behavior: auto;"
                     ],
                     [
                         "scroll-smooth",
-                        "scroll-behavior: smooth;",
-                        ""
+                        "scroll-behavior: smooth;"
                     ]
                 ]
             },
@@ -18923,8 +16556,7 @@
                 "table": [
                     [
                         "scroll-m-0",
-                        "scroll-margin: 0;",
-                        ""
+                        "scroll-margin: 0;"
                     ],
                     [
                         "scroll-m-0.5",
@@ -19078,18 +16710,15 @@
                     ],
                     [
                         "scroll-m-px",
-                        "scroll-margin: 1px;",
-                        ""
+                        "scroll-margin: 1px;"
                     ],
                     [
                         "scroll-my-0",
-                        "scroll-margin-top: 0;\nscroll-margin-bottom: 0;",
-                        ""
+                        "scroll-margin-top: 0;\nscroll-margin-bottom: 0;"
                     ],
                     [
                         "scroll-mx-0",
-                        "scroll-margin-left: 0;\nscroll-margin-right: 0;",
-                        ""
+                        "scroll-margin-left: 0;\nscroll-margin-right: 0;"
                     ],
                     [
                         "scroll-my-0.5",
@@ -19423,33 +17052,27 @@
                     ],
                     [
                         "scroll-my-px",
-                        "scroll-margin-top: 1px;\nscroll-margin-bottom: 1px;",
-                        ""
+                        "scroll-margin-top: 1px;\nscroll-margin-bottom: 1px;"
                     ],
                     [
                         "scroll-mx-px",
-                        "scroll-margin-left: 1px;\nscroll-margin-right: 1px;",
-                        ""
+                        "scroll-margin-left: 1px;\nscroll-margin-right: 1px;"
                     ],
                     [
                         "scroll-mt-0",
-                        "scroll-margin-top: 0;",
-                        ""
+                        "scroll-margin-top: 0;"
                     ],
                     [
                         "scroll-mr-0",
-                        "scroll-margin-right: 0;",
-                        ""
+                        "scroll-margin-right: 0;"
                     ],
                     [
                         "scroll-mb-0",
-                        "scroll-margin-bottom: 0;",
-                        ""
+                        "scroll-margin-bottom: 0;"
                     ],
                     [
                         "scroll-ml-0",
-                        "scroll-margin-left: 0;",
-                        ""
+                        "scroll-margin-left: 0;"
                     ],
                     [
                         "scroll-mt-0.5",
@@ -20113,23 +17736,19 @@
                     ],
                     [
                         "scroll-mt-px",
-                        "scroll-margin-top: 1px;",
-                        ""
+                        "scroll-margin-top: 1px;"
                     ],
                     [
                         "scroll-mr-px",
-                        "scroll-margin-right: 1px;",
-                        ""
+                        "scroll-margin-right: 1px;"
                     ],
                     [
                         "scroll-mb-px",
-                        "scroll-margin-bottom: 1px;",
-                        ""
+                        "scroll-margin-bottom: 1px;"
                     ],
                     [
                         "scroll-ml-px",
-                        "scroll-margin-left: 1px;",
-                        ""
+                        "scroll-margin-left: 1px;"
                     ]
                 ]
             },
@@ -20140,8 +17759,7 @@
                 "table": [
                     [
                         "scroll-p-0",
-                        "scroll-padding: 0;",
-                        ""
+                        "scroll-padding: 0;"
                     ],
                     [
                         "scroll-p-0.5",
@@ -20295,18 +17913,15 @@
                     ],
                     [
                         "scroll-p-px",
-                        "scroll-padding: 1px;",
-                        ""
+                        "scroll-padding: 1px;"
                     ],
                     [
                         "scroll-py-0",
-                        "scroll-padding-top: 0;\nscroll-padding-bottom: 0;",
-                        ""
+                        "scroll-padding-top: 0;\nscroll-padding-bottom: 0;"
                     ],
                     [
                         "scroll-px-0",
-                        "scroll-padding-left: 0;\nscroll-padding-right: 0;",
-                        ""
+                        "scroll-padding-left: 0;\nscroll-padding-right: 0;"
                     ],
                     [
                         "scroll-py-0.5",
@@ -20640,33 +18255,27 @@
                     ],
                     [
                         "scroll-py-px",
-                        "scroll-padding-top: 1px;\nscroll-padding-bottom: 1px;",
-                        ""
+                        "scroll-padding-top: 1px;\nscroll-padding-bottom: 1px;"
                     ],
                     [
                         "scroll-px-px",
-                        "scroll-padding-left: 1px;\nscroll-padding-right: 1px;",
-                        ""
+                        "scroll-padding-left: 1px;\nscroll-padding-right: 1px;"
                     ],
                     [
                         "scroll-pt-0",
-                        "scroll-padding-top: 0;",
-                        ""
+                        "scroll-padding-top: 0;"
                     ],
                     [
                         "scroll-pr-0",
-                        "scroll-padding-right: 0;",
-                        ""
+                        "scroll-padding-right: 0;"
                     ],
                     [
                         "scroll-pb-0",
-                        "scroll-padding-bottom: 0;",
-                        ""
+                        "scroll-padding-bottom: 0;"
                     ],
                     [
                         "scroll-pl-0",
-                        "scroll-padding-left: 0;",
-                        ""
+                        "scroll-padding-left: 0;"
                     ],
                     [
                         "scroll-pt-0.5",
@@ -21330,23 +18939,19 @@
                     ],
                     [
                         "scroll-pt-px",
-                        "scroll-padding-top: 1px;",
-                        ""
+                        "scroll-padding-top: 1px;"
                     ],
                     [
                         "scroll-pr-px",
-                        "scroll-padding-right: 1px;",
-                        ""
+                        "scroll-padding-right: 1px;"
                     ],
                     [
                         "scroll-pb-px",
-                        "scroll-padding-bottom: 1px;",
-                        ""
+                        "scroll-padding-bottom: 1px;"
                     ],
                     [
                         "scroll-pl-px",
-                        "scroll-padding-left: 1px;",
-                        ""
+                        "scroll-padding-left: 1px;"
                     ]
                 ]
             },
@@ -21357,23 +18962,19 @@
                 "table": [
                     [
                         "snap-start",
-                        "scroll-snap-align: start;",
-                        ""
+                        "scroll-snap-align: start;"
                     ],
                     [
                         "snap-end",
-                        "scroll-snap-align: end;",
-                        ""
+                        "scroll-snap-align: end;"
                     ],
                     [
                         "snap-center",
-                        "scroll-snap-align: center;",
-                        ""
+                        "scroll-snap-align: center;"
                     ],
                     [
                         "snap-align-none",
-                        "scroll-snap-align: align-none;",
-                        ""
+                        "scroll-snap-align: align-none;"
                     ]
                 ]
             },
@@ -21384,13 +18985,11 @@
                 "table": [
                     [
                         "snap-normal",
-                        "scroll-snap-stop: normal;",
-                        ""
+                        "scroll-snap-stop: normal;"
                     ],
                     [
                         "snap-always",
-                        "scroll-snap-stop: always;",
-                        ""
+                        "scroll-snap-stop: always;"
                     ]
                 ]
             },
@@ -21401,33 +19000,27 @@
                 "table": [
                     [
                         "snap-none",
-                        "scroll-snap-type: none;",
-                        ""
+                        "scroll-snap-type: none;"
                     ],
                     [
                         "snap-x",
-                        "scroll-snap-type: x var(--tw-scroll-snap-strictness);",
-                        ""
+                        "scroll-snap-type: x var(--tw-scroll-snap-strictness);"
                     ],
                     [
                         "snap-y",
-                        "scroll-snap-type: y var(--tw-scroll-snap-strictness);",
-                        ""
+                        "scroll-snap-type: y var(--tw-scroll-snap-strictness);"
                     ],
                     [
                         "snap-both",
-                        "scroll-snap-type: both var(--tw-scroll-snap-strictness);",
-                        ""
+                        "scroll-snap-type: both var(--tw-scroll-snap-strictness);"
                     ],
                     [
                         "snap-mandatory",
-                        "--tw-scroll-snap-strictness: mandatory;",
-                        ""
+                        "--tw-scroll-snap-strictness: mandatory;"
                     ],
                     [
                         "snap-proximity",
-                        "--tw-scroll-snap-strictness: proximity;",
-                        ""
+                        "--tw-scroll-snap-strictness: proximity;"
                     ]
                 ]
             },
@@ -21438,53 +19031,43 @@
                 "table": [
                     [
                         "touch-auto",
-                        "touch-action: auto;",
-                        ""
+                        "touch-action: auto;"
                     ],
                     [
                         "touch-none",
-                        "touch-action: none;",
-                        ""
+                        "touch-action: none;"
                     ],
                     [
                         "touch-pan-x",
-                        "touch-action: pan-x;",
-                        ""
+                        "touch-action: pan-x;"
                     ],
                     [
                         "touch-pan-left",
-                        "touch-action: pan-left;",
-                        ""
+                        "touch-action: pan-left;"
                     ],
                     [
                         "touch-pan-right",
-                        "touch-action: pan-right;",
-                        ""
+                        "touch-action: pan-right;"
                     ],
                     [
                         "touch-pan-y",
-                        "touch-action: pan-y;",
-                        ""
+                        "touch-action: pan-y;"
                     ],
                     [
                         "touch-pan-up",
-                        "touch-action: pan-up;",
-                        ""
+                        "touch-action: pan-up;"
                     ],
                     [
                         "touch-pan-down",
-                        "touch-action: pan-down;",
-                        ""
+                        "touch-action: pan-down;"
                     ],
                     [
                         "touch-pinch-zoom",
-                        "touch-action: pinch-zoom;",
-                        ""
+                        "touch-action: pinch-zoom;"
                     ],
                     [
                         "touch-manipulation",
-                        "touch-action: manipulation;",
-                        ""
+                        "touch-action: manipulation;"
                     ]
                 ]
             },
@@ -21495,23 +19078,19 @@
                 "table": [
                     [
                         "select-none",
-                        "user-select: none;",
-                        ""
+                        "user-select: none;"
                     ],
                     [
                         "select-text",
-                        "user-select: text;",
-                        ""
+                        "user-select: text;"
                     ],
                     [
                         "select-all",
-                        "user-select: all;",
-                        ""
+                        "user-select: all;"
                     ],
                     [
                         "select-auto",
-                        "user-select: auto;",
-                        ""
+                        "user-select: auto;"
                     ]
                 ]
             },
@@ -21522,23 +19101,19 @@
                 "table": [
                     [
                         "will-change-auto",
-                        "will-change: auto;",
-                        ""
+                        "will-change: auto;"
                     ],
                     [
                         "will-change-scroll",
-                        "will-change: scroll-position;",
-                        ""
+                        "will-change: scroll-position;"
                     ],
                     [
                         "will-change-contents",
-                        "will-change: contents;",
-                        ""
+                        "will-change: contents;"
                     ],
                     [
                         "will-change-transform",
-                        "will-change: transform;",
-                        ""
+                        "will-change: transform;"
                     ]
                 ]
             }
@@ -21554,8 +19129,7 @@
                 "table": [
                     [
                         "fill-current",
-                        "fill: currentColor;",
-                        ""
+                        "fill: currentColor;"
                     ]
                 ]
             },
@@ -21566,8 +19140,7 @@
                 "table": [
                     [
                         "stroke-current",
-                        "stroke: currentColor;",
-                        ""
+                        "stroke: currentColor;"
                     ]
                 ]
             },
@@ -21578,18 +19151,15 @@
                 "table": [
                     [
                         "stroke-0",
-                        "stroke-width: 0;",
-                        ""
+                        "stroke-width: 0;"
                     ],
                     [
                         "stroke-1",
-                        "stroke-width: 1;",
-                        ""
+                        "stroke-width: 1;"
                     ],
                     [
                         "stroke-2",
-                        "stroke-width: 2;",
-                        ""
+                        "stroke-width: 2;"
                     ]
                 ]
             }
@@ -21605,13 +19175,11 @@
                 "table": [
                     [
                         "border-collapse",
-                        "border-collapse: collapse;",
-                        ""
+                        "border-collapse: collapse;"
                     ],
                     [
                         "border-separate",
-                        "border-collapse: separate;",
-                        ""
+                        "border-collapse: separate;"
                     ]
                 ]
             },
@@ -21622,13 +19190,11 @@
                 "table": [
                     [
                         "table-auto",
-                        "table-layout: auto;",
-                        ""
+                        "table-layout: auto;"
                     ],
                     [
                         "table-fixed",
-                        "table-layout: fixed;",
-                        ""
+                        "table-layout: fixed;"
                     ]
                 ]
             }
@@ -21644,53 +19210,43 @@
                 "table": [
                     [
                         "shadow-xs",
-                        "box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05);",
-                        ""
+                        "box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05);"
                     ],
                     [
                         "shadow-sm",
-                        "box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);",
-                        ""
+                        "box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);"
                     ],
                     [
                         "shadow",
-                        "box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);",
-                        ""
+                        "box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);"
                     ],
                     [
                         "shadow-md",
-                        "box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);",
-                        ""
+                        "box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);"
                     ],
                     [
                         "shadow-lg",
-                        "box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);",
-                        ""
+                        "box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);"
                     ],
                     [
                         "shadow-xl",
-                        "box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);",
-                        ""
+                        "box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);"
                     ],
                     [
                         "shadow-2xl",
-                        "box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);",
-                        ""
+                        "box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);"
                     ],
                     [
                         "shadow-inner",
-                        "box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.06);",
-                        ""
+                        "box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.06);"
                     ],
                     [
                         "shadow-outline",
-                        "box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.5);",
-                        ""
+                        "box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.5);"
                     ],
                     [
                         "shadow-none",
-                        "box-shadow: none;",
-                        ""
+                        "box-shadow: none;"
                     ]
                 ]
             },
@@ -21701,73 +19257,59 @@
                 "table": [
                     [
                         "opacity-0",
-                        "opacity: 0;",
-                        ""
+                        "opacity: 0;"
                     ],
                     [
                         "opacity-5",
-                        "opacity: 0.05;",
-                        ""
+                        "opacity: 0.05;"
                     ],
                     [
                         "opacity-10",
-                        "opacity: 0.1;",
-                        ""
+                        "opacity: 0.1;"
                     ],
                     [
                         "opacity-20",
-                        "opacity: 0.2;",
-                        ""
+                        "opacity: 0.2;"
                     ],
                     [
                         "opacity-25",
-                        "opacity: 0.25;",
-                        ""
+                        "opacity: 0.25;"
                     ],
                     [
                         "opacity-30",
-                        "opacity: 0.3;",
-                        ""
+                        "opacity: 0.3;"
                     ],
                     [
                         "opacity-40",
-                        "opacity: 0.4;",
-                        ""
+                        "opacity: 0.4;"
                     ],
                     [
                         "opacity-50",
-                        "opacity: 0.5;",
-                        ""
+                        "opacity: 0.5;"
                     ],
                     [
                         "opacity-60",
-                        "opacity: 0.6;",
-                        ""
+                        "opacity: 0.6;"
                     ],
                     [
                         "opacity-70",
-                        "opacity: 0.7;",
-                        ""
+                        "opacity: 0.7;"
                     ],
                     [
                         "opacity-75",
-                        "opacity: 0.75;",
-                        ""
+                        "opacity: 0.75;"
                     ],
                     [
                         "opacity-80",
-                        "opacity: 0.8;",
-                        ""
+                        "opacity: 0.8;"
                     ],
                     [
                         "opacity-90",
-                        "opacity: 0.9;",
-                        ""
+                        "opacity: 0.9;"
                     ],
                     [
                         "opacity-100",
-                        "opacity: 1;",
-                        ""
+                        "opacity: 1;"
                     ]
                 ]
             },
@@ -21778,83 +19320,67 @@
                 "table": [
                     [
                         "mix-blend-normal",
-                        "mix-blend-mode: normal;",
-                        ""
+                        "mix-blend-mode: normal;"
                     ],
                     [
                         "mix-blend-multiply",
-                        "mix-blend-mode: multiply;",
-                        ""
+                        "mix-blend-mode: multiply;"
                     ],
                     [
                         "mix-blend-screen",
-                        "mix-blend-mode: screen;",
-                        ""
+                        "mix-blend-mode: screen;"
                     ],
                     [
                         "mix-blend-overlay",
-                        "mix-blend-mode: overlay;",
-                        ""
+                        "mix-blend-mode: overlay;"
                     ],
                     [
                         "mix-blend-darken",
-                        "mix-blend-mode: darken;",
-                        ""
+                        "mix-blend-mode: darken;"
                     ],
                     [
                         "mix-blend-lighten",
-                        "mix-blend-mode: lighten;",
-                        ""
+                        "mix-blend-mode: lighten;"
                     ],
                     [
                         "mix-blend-color-dodge",
-                        "mix-blend-mode: color-dodge;",
-                        ""
+                        "mix-blend-mode: color-dodge;"
                     ],
                     [
                         "mix-blend-color-burn",
-                        "mix-blend-mode: color-burn;",
-                        ""
+                        "mix-blend-mode: color-burn;"
                     ],
                     [
                         "mix-blend-hard-light",
-                        "mix-blend-mode: hard-light;",
-                        ""
+                        "mix-blend-mode: hard-light;"
                     ],
                     [
                         "mix-blend-soft-light",
-                        "mix-blend-mode: soft-light;",
-                        ""
+                        "mix-blend-mode: soft-light;"
                     ],
                     [
                         "mix-blend-difference",
-                        "mix-blend-mode: difference;",
-                        ""
+                        "mix-blend-mode: difference;"
                     ],
                     [
                         "mix-blend-exclusion",
-                        "mix-blend-mode: exclusion;",
-                        ""
+                        "mix-blend-mode: exclusion;"
                     ],
                     [
                         "mix-blend-hue",
-                        "mix-blend-mode: hue;",
-                        ""
+                        "mix-blend-mode: hue;"
                     ],
                     [
                         "mix-blend-saturation",
-                        "mix-blend-mode: saturation;",
-                        ""
+                        "mix-blend-mode: saturation;"
                     ],
                     [
                         "mix-blend-color",
-                        "mix-blend-mode: color;",
-                        ""
+                        "mix-blend-mode: color;"
                     ],
                     [
                         "mix-blend-luminosity",
-                        "mix-blend-mode: luminosity;",
-                        ""
+                        "mix-blend-mode: luminosity;"
                     ]
                 ]
             },
@@ -21865,83 +19391,67 @@
                 "table": [
                     [
                         "bg-blend-normal",
-                        "background-blend-mode: normal;",
-                        ""
+                        "background-blend-mode: normal;"
                     ],
                     [
                         "bg-blend-multiply",
-                        "background-blend-mode: multiply;",
-                        ""
+                        "background-blend-mode: multiply;"
                     ],
                     [
                         "bg-blend-screen",
-                        "background-blend-mode: screen;",
-                        ""
+                        "background-blend-mode: screen;"
                     ],
                     [
                         "bg-blend-overlay",
-                        "background-blend-mode: overlay;",
-                        ""
+                        "background-blend-mode: overlay;"
                     ],
                     [
                         "bg-blend-darken",
-                        "background-blend-mode: darken;",
-                        ""
+                        "background-blend-mode: darken;"
                     ],
                     [
                         "bg-blend-lighten",
-                        "background-blend-mode: lighten;",
-                        ""
+                        "background-blend-mode: lighten;"
                     ],
                     [
                         "bg-blend-color-dodge",
-                        "background-blend-mode: color-dodge;",
-                        ""
+                        "background-blend-mode: color-dodge;"
                     ],
                     [
                         "bg-blend-color-burn",
-                        "background-blend-mode: color-burn;",
-                        ""
+                        "background-blend-mode: color-burn;"
                     ],
                     [
                         "bg-blend-hard-light",
-                        "background-blend-mode: hard-light;",
-                        ""
+                        "background-blend-mode: hard-light;"
                     ],
                     [
                         "bg-blend-soft-light",
-                        "background-blend-mode: soft-light;",
-                        ""
+                        "background-blend-mode: soft-light;"
                     ],
                     [
                         "bg-blend-difference",
-                        "background-blend-mode: difference;",
-                        ""
+                        "background-blend-mode: difference;"
                     ],
                     [
                         "bg-blend-exclusion",
-                        "background-blend-mode: exclusion;",
-                        ""
+                        "background-blend-mode: exclusion;"
                     ],
                     [
                         "bg-blend-hue",
-                        "background-blend-mode: hue;",
-                        ""
+                        "background-blend-mode: hue;"
                     ],
                     [
                         "bg-blend-saturation",
-                        "background-blend-mode: saturation;",
-                        ""
+                        "background-blend-mode: saturation;"
                     ],
                     [
                         "bg-blend-color",
-                        "background-blend-mode: color;",
-                        ""
+                        "background-blend-mode: color;"
                     ],
                     [
                         "bg-blend-luminosity",
-                        "background-blend-mode: luminosity;",
-                        ""
+                        "background-blend-mode: luminosity;"
                     ]
                 ]
             }
@@ -21957,43 +19467,35 @@
                 "table": [
                     [
                         "blur-none",
-                        "blur: blur(0);",
-                        ""
+                        "blur: blur(0);"
                     ],
                     [
                         "blur-sm",
-                        "blur: blur(4px);",
-                        ""
+                        "blur: blur(4px);"
                     ],
                     [
                         "blur",
-                        "blur: blur(8px);",
-                        ""
+                        "blur: blur(8px);"
                     ],
                     [
                         "blur-md",
-                        "blur: blur(12px);",
-                        ""
+                        "blur: blur(12px);"
                     ],
                     [
                         "blur-lg",
-                        "blur: blur(16px);",
-                        ""
+                        "blur: blur(16px);"
                     ],
                     [
                         "blur-xl",
-                        "blur: blur(24px);",
-                        ""
+                        "blur: blur(24px);"
                     ],
                     [
                         "blur-2xl",
-                        "blur: blur(40px);",
-                        ""
+                        "blur: blur(40px);"
                     ],
                     [
                         "blur-3xl",
-                        "blur: blur(64px);",
-                        ""
+                        "blur: blur(64px);"
                     ]
                 ]
             },
@@ -22004,58 +19506,47 @@
                 "table": [
                     [
                         "brightness-0",
-                        "brightness: brightness(0);",
-                        ""
+                        "brightness: brightness(0);"
                     ],
                     [
                         "brightness-50",
-                        "brightness: brightness(.5);",
-                        ""
+                        "brightness: brightness(.5);"
                     ],
                     [
                         "brightness-75",
-                        "brightness: brightness(.75);",
-                        ""
+                        "brightness: brightness(.75);"
                     ],
                     [
                         "brightness-90",
-                        "brightness: brightness(.9);",
-                        ""
+                        "brightness: brightness(.9);"
                     ],
                     [
                         "brightness-95",
-                        "brightness: brightness(.95);",
-                        ""
+                        "brightness: brightness(.95);"
                     ],
                     [
                         "brightness-100",
-                        "brightness: brightness(1);",
-                        ""
+                        "brightness: brightness(1);"
                     ],
                     [
                         "brightness-105",
-                        "brightness: brightness(1.05);",
-                        ""
+                        "brightness: brightness(1.05);"
                     ],
                     [
                         "brightness-110",
-                        "brightness: brightness(1.1);",
-                        ""
+                        "brightness: brightness(1.1);"
                     ],
                     [
                         "brightness-125",
-                        "brightness: brightness(1.25);",
-                        ""
+                        "brightness: brightness(1.25);"
                     ],
                     [
                         "brightness-150",
-                        "brightness: brightness(1.5);",
-                        ""
+                        "brightness: brightness(1.5);"
                     ],
                     [
                         "brightness-200",
-                        "brightness: brightness(2);",
-                        ""
+                        "brightness: brightness(2);"
                     ]
                 ]
             },
@@ -22066,38 +19557,31 @@
                 "table": [
                     [
                         "contrast-0",
-                        "contrast: contrast(0);",
-                        ""
+                        "contrast: contrast(0);"
                     ],
                     [
                         "contrast-50",
-                        "contrast: contrast(.5);",
-                        ""
+                        "contrast: contrast(.5);"
                     ],
                     [
                         "contrast-75",
-                        "contrast: contrast(.75);",
-                        ""
+                        "contrast: contrast(.75);"
                     ],
                     [
                         "contrast-100",
-                        "contrast: contrast(1);",
-                        ""
+                        "contrast: contrast(1);"
                     ],
                     [
                         "contrast-125",
-                        "contrast: contrast(1.25);",
-                        ""
+                        "contrast: contrast(1.25);"
                     ],
                     [
                         "contrast-150",
-                        "contrast: contrast(1.5);",
-                        ""
+                        "contrast: contrast(1.5);"
                     ],
                     [
                         "contrast-200",
-                        "contrast: contrast(2);",
-                        ""
+                        "contrast: contrast(2);"
                     ]
                 ]
             },
@@ -22108,38 +19592,31 @@
                 "table": [
                     [
                         "drop-shadow-sm",
-                        "drop-shadow: drop-shadow(0 1px 1px rgba(0,0,0,0.05));",
-                        ""
+                        "drop-shadow: drop-shadow(0 1px 1px rgba(0,0,0,0.05));"
                     ],
                     [
                         "drop-shadow",
-                        "drop-shadow: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.06));",
-                        ""
+                        "drop-shadow: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.06));"
                     ],
                     [
                         "drop-shadow-md",
-                        "drop-shadow: drop-shadow(0 4px 3px rgba(0, 0, 0, 0.07)) drop-shadow(0 2px 2px rgba(0, 0, 0, 0.06));",
-                        ""
+                        "drop-shadow: drop-shadow(0 4px 3px rgba(0, 0, 0, 0.07)) drop-shadow(0 2px 2px rgba(0, 0, 0, 0.06));"
                     ],
                     [
                         "drop-shadow-lg",
-                        "drop-shadow: drop-shadow(0 10px 8px rgba(0, 0, 0, 0.04)) drop-shadow(0 4px 3px rgba(0, 0, 0, 0.1));",
-                        ""
+                        "drop-shadow: drop-shadow(0 10px 8px rgba(0, 0, 0, 0.04)) drop-shadow(0 4px 3px rgba(0, 0, 0, 0.1));"
                     ],
                     [
                         "drop-shadow-xl",
-                        "drop-shadow: drop-shadow(0 20px 13px rgba(0, 0, 0, 0.03)) drop-shadow(0 8px 5px rgba(0, 0, 0, 0.08));",
-                        ""
+                        "drop-shadow: drop-shadow(0 20px 13px rgba(0, 0, 0, 0.03)) drop-shadow(0 8px 5px rgba(0, 0, 0, 0.08));"
                     ],
                     [
                         "drop-shadow-2xl",
-                        "drop-shadow: drop-shadow: drop-shadow(0 25px 25px rgba(0, 0, 0, 0.15));",
-                        ""
+                        "drop-shadow: drop-shadow: drop-shadow(0 25px 25px rgba(0, 0, 0, 0.15));"
                     ],
                     [
                         "drop-shadow-none",
-                        "drop-shadow: drop-shadow: drop-shadow(0 0 #0000);",
-                        ""
+                        "drop-shadow: drop-shadow: drop-shadow(0 0 #0000);"
                     ]
                 ]
             },
@@ -22150,13 +19627,11 @@
                 "table": [
                     [
                         "grayscale-0",
-                        "grayscale: grayscale(0);",
-                        ""
+                        "grayscale: grayscale(0);"
                     ],
                     [
                         "grayscale",
-                        "grayscale: grayscale(1);",
-                        ""
+                        "grayscale: grayscale(1);"
                     ]
                 ]
             },
@@ -22167,33 +19642,27 @@
                 "table": [
                     [
                         "hue-rotate-0",
-                        "hue-rotate: hue-rotate(0deg);",
-                        ""
+                        "hue-rotate: hue-rotate(0deg);"
                     ],
                     [
                         "hue-rotate-15",
-                        "hue-rotate: hue-rotate(15deg);",
-                        ""
+                        "hue-rotate: hue-rotate(15deg);"
                     ],
                     [
                         "hue-rotate-30",
-                        "hue-rotate: hue-rotate(30deg);",
-                        ""
+                        "hue-rotate: hue-rotate(30deg);"
                     ],
                     [
                         "hue-rotate-60",
-                        "hue-rotate: hue-rotate(60deg);",
-                        ""
+                        "hue-rotate: hue-rotate(60deg);"
                     ],
                     [
                         "hue-rotate-90",
-                        "hue-rotate: hue-rotate(90deg);",
-                        ""
+                        "hue-rotate: hue-rotate(90deg);"
                     ],
                     [
                         "hue-rotate-180",
-                        "hue-rotate: hue-rotate(180deg);",
-                        ""
+                        "hue-rotate: hue-rotate(180deg);"
                     ]
                 ]
             },
@@ -22204,13 +19673,11 @@
                 "table": [
                     [
                         "invert-0",
-                        "invert: invert(0);",
-                        ""
+                        "invert: invert(0);"
                     ],
                     [
                         "invert",
-                        "invert: invert(1);",
-                        ""
+                        "invert: invert(1);"
                     ]
                 ]
             },
@@ -22221,28 +19688,23 @@
                 "table": [
                     [
                         "saturate-0",
-                        "saturate: saturate(0);",
-                        ""
+                        "saturate: saturate(0);"
                     ],
                     [
                         "saturate-50",
-                        "saturate: saturate(.5);",
-                        ""
+                        "saturate: saturate(.5);"
                     ],
                     [
                         "saturate-100",
-                        "saturate: saturate(1);",
-                        ""
+                        "saturate: saturate(1);"
                     ],
                     [
                         "saturate-150",
-                        "saturate: saturate(1.50);",
-                        ""
+                        "saturate: saturate(1.50);"
                     ],
                     [
                         "saturate-200",
-                        "saturate: saturate(2);",
-                        ""
+                        "saturate: saturate(2);"
                     ]
                 ]
             },
@@ -22253,13 +19715,11 @@
                 "table": [
                     [
                         "sepia-0",
-                        "sepia: sepia(0);",
-                        ""
+                        "sepia: sepia(0);"
                     ],
                     [
                         "sepia",
-                        "sepia: sepia(1);",
-                        ""
+                        "sepia: sepia(1);"
                     ]
                 ]
             },
@@ -22270,43 +19730,35 @@
                 "table": [
                     [
                         "backdrop-blur-none",
-                        "backdrop-blur: blur(0);",
-                        ""
+                        "backdrop-blur: blur(0);"
                     ],
                     [
                         "backdrop-blur-sm",
-                        "backdrop-blur: blur(4px);",
-                        ""
+                        "backdrop-blur: blur(4px);"
                     ],
                     [
                         "backdrop-blur",
-                        "backdrop-blur: blur(8px);",
-                        ""
+                        "backdrop-blur: blur(8px);"
                     ],
                     [
                         "backdrop-blur-md",
-                        "backdrop-blur: blur(12px);",
-                        ""
+                        "backdrop-blur: blur(12px);"
                     ],
                     [
                         "backdrop-blur-lg",
-                        "backdrop-blur: blur(16px);",
-                        ""
+                        "backdrop-blur: blur(16px);"
                     ],
                     [
                         "backdrop-blur-xl",
-                        "backdrop-blur: blur(24px);",
-                        ""
+                        "backdrop-blur: blur(24px);"
                     ],
                     [
                         "backdrop-blur-2xl",
-                        "backdrop-blur: blur(40px);",
-                        ""
+                        "backdrop-blur: blur(40px);"
                     ],
                     [
                         "backdrop-blur-3xl",
-                        "backdrop-blur: blur(64px);",
-                        ""
+                        "backdrop-blur: blur(64px);"
                     ]
                 ]
             },
@@ -22317,43 +19769,35 @@
                 "table": [
                     [
                         "backdrop-brightness-0",
-                        "backdrop-brightness: brightness(0);",
-                        ""
+                        "backdrop-brightness: brightness(0);"
                     ],
                     [
                         "backdrop-brightness-sm",
-                        "backdrop-brightness: brightness(4px);",
-                        ""
+                        "backdrop-brightness: brightness(4px);"
                     ],
                     [
                         "backdrop-brightness",
-                        "backdrop-brightness: brightness(8px);",
-                        ""
+                        "backdrop-brightness: brightness(8px);"
                     ],
                     [
                         "backdrop-brightness-md",
-                        "backdrop-brightness: brightness(12px);",
-                        ""
+                        "backdrop-brightness: brightness(12px);"
                     ],
                     [
                         "backdrop-brightness-lg",
-                        "backdrop-brightness: brightness(16px);",
-                        ""
+                        "backdrop-brightness: brightness(16px);"
                     ],
                     [
                         "backdrop-brightness-xl",
-                        "backdrop-brightness: brightness(24px);",
-                        ""
+                        "backdrop-brightness: brightness(24px);"
                     ],
                     [
                         "backdrop-brightness-2xl",
-                        "backdrop-brightness: brightness(40px);",
-                        ""
+                        "backdrop-brightness: brightness(40px);"
                     ],
                     [
                         "backdrop-brightness-3xl",
-                        "backdrop-brightness: brightness(64px);",
-                        ""
+                        "backdrop-brightness: brightness(64px);"
                     ]
                 ]
             },
@@ -22364,38 +19808,31 @@
                 "table": [
                     [
                         "backdrop-contrast-0",
-                        "backdrop-contrast: contrast(0);",
-                        ""
+                        "backdrop-contrast: contrast(0);"
                     ],
                     [
                         "backdrop-contrast-50",
-                        "backdrop-contrast: contrast(.5);",
-                        ""
+                        "backdrop-contrast: contrast(.5);"
                     ],
                     [
                         "backdrop-contrast-75",
-                        "backdrop-contrast: contrast(.75);",
-                        ""
+                        "backdrop-contrast: contrast(.75);"
                     ],
                     [
                         "backdrop-contrast-100",
-                        "backdrop-contrast: contrast(1);",
-                        ""
+                        "backdrop-contrast: contrast(1);"
                     ],
                     [
                         "backdrop-contrast-125",
-                        "backdrop-contrast: contrast(1.25);",
-                        ""
+                        "backdrop-contrast: contrast(1.25);"
                     ],
                     [
                         "backdrop-contrast-150",
-                        "backdrop-contrast: contrast(1.5);",
-                        ""
+                        "backdrop-contrast: contrast(1.5);"
                     ],
                     [
                         "backdrop-contrast-200",
-                        "backdrop-contrast: contrast(2);",
-                        ""
+                        "backdrop-contrast: contrast(2);"
                     ]
                 ]
             },
@@ -22406,13 +19843,11 @@
                 "table": [
                     [
                         "backdrop-grayscale-0",
-                        "backdrop-grayscale: grayscale(0);",
-                        ""
+                        "backdrop-grayscale: grayscale(0);"
                     ],
                     [
                         "backdrop-grayscale",
-                        "backdrop-grayscale: grayscale(1);",
-                        ""
+                        "backdrop-grayscale: grayscale(1);"
                     ]
                 ]
             },
@@ -22423,33 +19858,27 @@
                 "table": [
                     [
                         "backdrop-hue-rotate-0",
-                        "backdrop-hue-rotate: hue-rotate(0deg);",
-                        ""
+                        "backdrop-hue-rotate: hue-rotate(0deg);"
                     ],
                     [
                         "backdrop-hue-rotate-15",
-                        "backdrop-hue-rotate: hue-rotate(15deg);",
-                        ""
+                        "backdrop-hue-rotate: hue-rotate(15deg);"
                     ],
                     [
                         "backdrop-hue-rotate-30",
-                        "backdrop-hue-rotate: hue-rotate(30deg);",
-                        ""
+                        "backdrop-hue-rotate: hue-rotate(30deg);"
                     ],
                     [
                         "backdrop-hue-rotate-60",
-                        "backdrop-hue-rotate: hue-rotate(60deg);",
-                        ""
+                        "backdrop-hue-rotate: hue-rotate(60deg);"
                     ],
                     [
                         "backdrop-hue-rotate-90",
-                        "backdrop-hue-rotate: hue-rotate(90deg);",
-                        ""
+                        "backdrop-hue-rotate: hue-rotate(90deg);"
                     ],
                     [
                         "backdrop-hue-rotate-180",
-                        "backdrop-hue-rotate: hue-rotate(180deg);",
-                        ""
+                        "backdrop-hue-rotate: hue-rotate(180deg);"
                     ]
                 ]
             },
@@ -22460,15 +19889,13 @@
                 "table": [
                     [
                         "backdrop-invert-0",
-                        "backdrop-invert: invert(0);",
-                        ""
+                        "backdrop-invert: invert(0);"
                     ],
                     [
                         "backdrop-invert",
-                        "backdrop-invert: invert(1);",
-                        ""
+                        "backdrop-invert: invert(1);"
                     ]
-             
+
                 ]
             },
             {
@@ -22478,78 +19905,63 @@
                 "table": [
                     [
                         "backdrop-opacity-0",
-                        "backdrop-opacity: opacity(0);",
-                        ""
+                        "backdrop-opacity: opacity(0);"
                     ],
                     [
                         "backdrop-opacity-5",
-                        "backdrop-opacity: opacity(0.05);",
-                        ""
+                        "backdrop-opacity: opacity(0.05);"
                     ],
                     [
                         "backdrop-opacity-10",
-                        "backdrop-opacity: opacity(0.1);",
-                        ""
+                        "backdrop-opacity: opacity(0.1);"
                     ],
                     [
                         "backdrop-opacity-20",
-                        "backdrop-opacity: opacity(0.2);",
-                        ""
+                        "backdrop-opacity: opacity(0.2);"
                     ],
                     [
                         "backdrop-opacity-25",
-                        "backdrop-opacity: opacity(0.25);",
-                        ""
+                        "backdrop-opacity: opacity(0.25);"
                     ],
                     [
                         "backdrop-opacity-30",
-                        "backdrop-opacity: opacity(0.3);",
-                        ""
+                        "backdrop-opacity: opacity(0.3);"
                     ],
                     [
                         "backdrop-opacity-40",
-                        "backdrop-opacity: opacity(0.4);",
-                        ""
+                        "backdrop-opacity: opacity(0.4);"
                     ],
                     [
                         "backdrop-opacity-50",
-                        "backdrop-opacity: opacity(0.5);",
-                        ""
+                        "backdrop-opacity: opacity(0.5);"
                     ],
                     [
                         "backdrop-opacity-60",
-                        "backdrop-opacity: opacity(0.6);",
-                        ""
+                        "backdrop-opacity: opacity(0.6);"
                     ],
                     [
                         "backdrop-opacity-70",
-                        "backdrop-opacity: opacity(0.7);",
-                        ""
+                        "backdrop-opacity: opacity(0.7);"
                     ],
                     [
                         "backdrop-opacity-75",
-                        "backdrop-opacity: opacity(0.75);",
-                        ""
+                        "backdrop-opacity: opacity(0.75);"
                     ],
                     [
                         "backdrop-opacity-80",
-                        "backdrop-opacity: opacity(0.8);",
-                        ""
+                        "backdrop-opacity: opacity(0.8);"
                     ],
                     [
                         "backdrop-opacity-90",
-                        "backdrop-opacity: opacity(0.9);",
-                        ""
+                        "backdrop-opacity: opacity(0.9);"
                     ],
                     [
                         "backdrop-opacity-95",
-                        "backdrop-opacity: opacity(0.95);",
-                        ""
+                        "backdrop-opacity: opacity(0.95);"
                     ],
                     [
                         "backdrop-opacity-100",
-                        "backdrop-opacity: opacity(1);",
-                        ""
+                        "backdrop-opacity: opacity(1);"
                     ]
                 ]
             },
@@ -22560,28 +19972,23 @@
                 "table": [
                     [
                         "backdrop-saturate-0",
-                        "backdrop-saturate: saturate(0);",
-                        ""
+                        "backdrop-saturate: saturate(0);"
                     ],
                     [
                         "backdrop-saturate-50",
-                        "backdrop-saturate: saturate(.5);",
-                        ""
+                        "backdrop-saturate: saturate(.5);"
                     ],
                     [
                         "backdrop-saturate-100",
-                        "backdrop-saturate: saturate(1);",
-                        ""
+                        "backdrop-saturate: saturate(1);"
                     ],
                     [
                         "backdrop-saturate-150",
-                        "backdrop-saturate: saturate(1.50);",
-                        ""
+                        "backdrop-saturate: saturate(1.50);"
                     ],
                     [
                         "backdrop-saturate-200",
-                        "backdrop-saturate: saturate(2);",
-                        ""
+                        "backdrop-saturate: saturate(2);"
                     ]
                 ]
             },
@@ -22592,13 +19999,11 @@
                 "table": [
                     [
                         "backdrop-sepia-0",
-                        "backdrop-sepia: sepia(0);",
-                        ""
+                        "backdrop-sepia: sepia(0);"
                     ],
                     [
                         "backdrop-sepia",
-                        "backdrop-sepia: sepia(1);",
-                        ""
+                        "backdrop-sepia: sepia(1);"
                     ]
                 ]
             }
@@ -22614,13 +20019,11 @@
                 "table": [
                     [
                         "sr-only",
-                        "position: absolute;\nwidth: 1px;\nheight: 1px;\npadding: 0;\nmargin: -1px;\noverflow: hidden;\nclip: rect(0, 0, 0, 0);\nwhite-space: nowrap;\nborder-width: 0;",
-                        ""
+                        "position: absolute;\nwidth: 1px;\nheight: 1px;\npadding: 0;\nmargin: -1px;\noverflow: hidden;\nclip: rect(0, 0, 0, 0);\nwhite-space: nowrap;\nborder-width: 0;"
                     ],
                     [
                         "not-sr-only",
-                        "position: static;\nwidth: auto;\nheight: auto;\npadding: 0;\nmargin: 0;\noverflow: visible;\nclip: auto;\nwhite-space: normal;",
-                        ""
+                        "position: static;\nwidth: auto;\nheight: auto;\npadding: 0;\nmargin: 0;\noverflow: visible;\nclip: auto;\nwhite-space: normal;"
                     ]
                 ]
             }

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -20,34 +20,37 @@ const Home = (props: any) => {
 
     const search = (text: string) => {
         let newCheatsheet: Category[] = json.map((category: Category) => {
-            return {
-                // TODO try to add category table into considiration when searching. should reduce mapping
-                title: category.title,
-                content: category.content.map((subcategory: Subcategory) => {
-					// Si el texto de búsqueda existe en el título o la descripción se muestra toda la tabla, si no pues se filtra en ella
-					// If the search text exists in the title or description, the entire table is displayed, if not, then it is filtered on it
-					if (
-						subcategory.title.toLowerCase().includes(text) ||
-						subcategory.description.toLowerCase().includes(text)
-					) {
-						return subcategory;
-					} else {
-						return {
-							title: subcategory.title,
-							docs: subcategory.docs,
-							description: subcategory.description,
-							table: subcategory.table.filter((tr) => {
-								//no forEach needed as we need only one match to show entire row
-								for (let td = 0; td < tr.length; td++) {
-									if (tr[td].includes(text)) {
-										return true;
-									}
-								}
-								return false;
-							}),
-						};
-					}
-				}),
+            if (category.title.toLowerCase().includes(text)) {
+                return category;
+            } else {
+                return {
+                    title: category.title,
+                    content: category.content.map((subcategory: Subcategory) => {
+                        // Si el texto de búsqueda existe en el título o la descripción se muestra toda la tabla, si no pues se filtra en ella
+                        // If the search text exists in the title or description, the entire table is displayed, if not, then it is filtered on it
+                        if (
+                            subcategory.title.toLowerCase().includes(text) ||
+                            subcategory.description.toLowerCase().includes(text)
+                        ) {
+                            return subcategory;
+                        } else {
+                            return {
+                                title: subcategory.title,
+                                docs: subcategory.docs,
+                                description: subcategory.description,
+                                table: subcategory.table.filter((tr) => {
+                                    //no forEach needed as we need only one match to show entire row
+                                    for (let td = 0; td < tr.length; td++) {
+                                        if (tr[td].includes(text)) {
+                                            return true;
+                                        }
+                                    }
+                                    return false;
+                                }),
+                            };
+                        }
+                    })
+                }
             };
         });
 

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -47,7 +47,7 @@ const Home = (props: any) => {
     };
 
     return (
-        <main className={"tracking-wide font-roboto min-h-screen grid " + (JSON.parse(localStorage.getItem('darkMode') || '{}') ? 'dark bg-gray-900' : '')}>
+        <main className={"tracking-wide font-roboto min-h-screen grid content-start " + (JSON.parse(localStorage.getItem('darkMode') || '{}') ? 'dark bg-gray-900' : '')}>
             <SearchBar search={search} />
             <Tagline />
             <Categories cheatsheet={cheatsheet} />

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -21,24 +21,33 @@ const Home = (props: any) => {
     const search = (text: string) => {
         let newCheatsheet: Category[] = json.map((category: Category) => {
             return {
-                ...category,
-                'content': category.content.map((subcategory: Subcategory) => {
-                    return {
-                        ...subcategory,
-                        // Si el texto de búsqueda existe en el título o la descripción se muestra toda la tabla, si no pues se filtra en ella
-                        'table': subcategory.title.includes(text) || subcategory.description.includes(text) ? subcategory.table : subcategory.table.filter(tr => {
-                            let isValid = false;
-
-                            tr.forEach(td => {
-                                if (!isValid) {
-                                    isValid = td.includes(text);
-                                }
-                            });
-
-                            return isValid;
-                        }),
-                    };
-                }),
+                // TODO try to add category table into considiration when searching. should reduce mapping
+                title: category.title,
+                content: category.content.map((subcategory: Subcategory) => {
+					// Si el texto de búsqueda existe en el título o la descripción se muestra toda la tabla, si no pues se filtra en ella
+					// If the search text exists in the title or description, the entire table is displayed, if not, then it is filtered on it
+					if (
+						subcategory.title.toLowerCase().includes(text) ||
+						subcategory.description.toLowerCase().includes(text)
+					) {
+						return subcategory;
+					} else {
+						return {
+							title: subcategory.title,
+							docs: subcategory.docs,
+							description: subcategory.description,
+							table: subcategory.table.filter((tr) => {
+								//no forEach needed as we need only one match to show entire row
+								for (let td = 0; td < tr.length; td++) {
+									if (tr[td].includes(text)) {
+										return true;
+									}
+								}
+								return false;
+							}),
+						};
+					}
+				}),
             };
         });
 

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -8,6 +8,7 @@ import { trackView, trackSearch } from '../utils/googleAnalytics';
 import SearchBar from '../components/searchBar';
 import Categories from '../components/categories';
 import Footer from '../components/footer';
+import Tagline from '../components/tagline';
 
 const Home = (props: any) => {
     const json: Category[] = require('../modules/cheatsheet.json');
@@ -48,6 +49,7 @@ const Home = (props: any) => {
     return (
         <main className={"tracking-wide font-roboto min-h-screen grid " + (JSON.parse(localStorage.getItem('darkMode') || '{}') ? 'dark bg-gray-900' : '')}>
             <SearchBar search={search} />
+            <Tagline />
             <Categories cheatsheet={cheatsheet} />
             <Footer />
         </main>


### PR DESCRIPTION
Small fixes and changes:
- Moved `<Tagline />` to separate component, so it won't rerender with `<Masonry />`
- Removed opacity tracking in `<Category />` because header is `lg:z-50` now
- Changed `height: 0px` to `display: none` in `<Subcategory />`, in hope that it'll speed up DOM updates
- Removed empty JSON string from `cheatsheet.json` to fix empty column bug i found:

### Bug reproduction:
![Bug example](https://github.com/tailwindcomponents/cheatsheet/assets/19977559/7e25bdfc-947c-422a-97aa-526e21aae48d)
If clicked on empty space (painted red) where pixel unit comparison usually is, empty string from `cheatsheet.json` would be copied to clipboard.
After removing these strings `cheatsheet.json` is now 11.5% smaller, so it could improve performance by a little.
