### PR TITLE
Corrections for flex and outline

### DIFF
--- a/src/modules/cheatsheet.json
+++ b/src/modules/cheatsheet.json
@@ -10380,7 +10380,7 @@
                     ],
                     [
                         "outline-none",
-                        "outline-style: none;"
+                        "outline-style: none; outline: 2px solid transparent; outline-offset: 2px;"
                     ]
                 ]
             },

--- a/src/modules/cheatsheet.json
+++ b/src/modules/cheatsheet.json
@@ -10379,10 +10379,6 @@
                         "outline-style: double;"
                     ],
                     [
-                        "outline-hidden",
-                        "outline-style: hidden;"
-                    ],
-                    [
                         "outline-none",
                         "outline-style: none;"
                     ]

--- a/src/modules/cheatsheet.json
+++ b/src/modules/cheatsheet.json
@@ -7471,7 +7471,7 @@
                 "description": "Controls how flex items grow.",
                 "table": [
                     [
-                        "flex-grow",
+                        "grow",
                         "flex-grow: 1;"
                     ],
                     [
@@ -10363,7 +10363,7 @@
                 "description": "Utilities for controlling the style of an element's outline.",
                 "table": [
                     [
-                        "outline-solid",
+                        "outline",
                         "outline-style: solid;"
                     ],
                     [


### PR DESCRIPTION
I made some corrections for outline. It  looks like outline was copied from border, but there are some subtle differences in how outline is used.

There isn't an outline-solid -- it's just outline -- and I removed outline-hidden as hidden doesn't exist for outline. I also updated outline-none to reflect what Tailwind applies when it is used.

I also updated flex-grow to reflect #35.

https://tailwindcss.com/docs/outline-style
https://tailwindcss.com/docs/flex-grow