### PR TITLE
Update rounded px values to match tw docs

### DIFF
--- a/src/modules/cheatsheet.json
+++ b/src/modules/cheatsheet.json
@@ -8768,17 +8768,17 @@
                     [
                         "rounded-xl",
                         "border-radius: 0.75rem;",
-                        "10px"
+                        "12px"
                     ],
                     [
                         "rounded-2xl",
                         "border-radius: 1rem;",
-                        "12px"
+                        "16px"
                     ],
                     [
                         "rounded-3xl",
                         "border-radius: 1.5rem;",
-                        "16px"
+                        "24px"
                     ],
                     [
                         "rounded-full",


### PR DESCRIPTION
# Update rounded px values to match tw docs

Related to issue https://github.com/tailwindcomponents/cheatsheet/issues/41

Official TW docs
<img width="482" alt="image" src="https://github.com/tailwindcomponents/cheatsheet/assets/106735445/edf5a8b3-729c-4a53-81bb-6b5b45cc8910">


## Before PR
Tailwind cheatsheet
<img width="381" alt="image" src="https://github.com/tailwindcomponents/cheatsheet/assets/106735445/fc5746c3-07c6-4e24-8779-ed687d69a238">

## After PR
PR will update values to match TW docs.