### PR TITLE
Fix grammatical error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="src/images/cheatsheet.png" alt="Ibis logo">
 
 ## Tailwindcomponents Cheatsheet]
-This repo content a cheatsheet page from [tailwindcomponents.com](https://tailwindcomponents.com/cheatsheet/), it's react base app build with typescript.
+This repo content a cheatsheet page from [tailwindcomponents.com](https://tailwindcomponents.com/cheatsheet/), it's a react base app build with typescript.
 
 <a href="https://github.com/tailwindcomponents/cheatsheet/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/tailwindcomponents/cheatsheet">


### PR DESCRIPTION
It seems like there's supposed to be an 'a' after 'it's react base app'.