### PR TITLE
Fix bg-opacity-5 translation (Issue 52)

### DIFF
--- a/src/modules/cheatsheet.json
+++ b/src/modules/cheatsheet.json
@@ -13996,7 +13996,7 @@
                     ],
                     [
                         "bg-opacity-5",
-                        "--bg-opacity: 0.5;"
+                        "--bg-opacity: 0.05;"
                     ],
                     [
                         "bg-opacity-10",


### PR DESCRIPTION
**Issue**
[Issue 52](https://github.com/tailwindcomponents/cheatsheet/issues/52)

**Description**
Fix translation of `bg-opacity-5`

❌ `--bg-opacity: 0.5;`
✅ `--bg-opacity: 0.05;`